### PR TITLE
Some visual tweaks

### DIFF
--- a/Classes/PreferencesViewController.swift
+++ b/Classes/PreferencesViewController.swift
@@ -24,22 +24,22 @@ final class PreferencesViewController : NSViewController {
 		tableView.window?.makeFirstResponder(tableView)
 	}
 
-    @IBAction func performAction(sender: NSSegmentedControl) {
-        if sender.selectedSegment == 0 {
-            let oPanel = NSOpenPanel()
+	@IBAction func performAction(sender: NSSegmentedControl) {
+		if sender.selectedSegment == 0 {
+			let oPanel = NSOpenPanel()
 
-            oPanel.allowsMultipleSelection = true
-            oPanel.canChooseDirectories = true
-            oPanel.canChooseFiles = false
-            oPanel.treatsFilePackagesAsDirectories = true
+			oPanel.allowsMultipleSelection = true
+			oPanel.canChooseDirectories = true
+			oPanel.canChooseFiles = false
+			oPanel.treatsFilePackagesAsDirectories = true
 
-            oPanel.beginWithCompletionHandler { result in
-                if NSModalResponseOK == result {
-                    self.roots.addObjects(oPanel.URLs.map { [ "Path" : $0.path!, "Languages" : true, "Architectures" : true ] })
-                }
-            }
-        } else if sender.selectedSegment == 1 {
-            roots.remove(sender)
-        }
-    }
+			oPanel.beginWithCompletionHandler { result in
+				if NSModalResponseOK == result {
+					self.roots.addObjects(oPanel.URLs.map { [ "Path" : $0.path!, "Languages" : true, "Architectures" : true ] })
+				}
+			}
+		} else if sender.selectedSegment == 1 {
+			roots.remove(sender)
+		}
+	}
 }

--- a/Classes/PreferencesViewController.swift
+++ b/Classes/PreferencesViewController.swift
@@ -16,26 +16,30 @@ final class PreferencesViewController : NSViewController {
 	// Ugly workaround to force NSUserDefaultsController to notice the model changes from the UI.
 	// This currently seems broken for view-based NSTableViews (the changes to the objectValue property are not propagated).
 	@IBAction func togglePreference(sender: AnyObject) {
-		let selectionIndex = self.roots.selectionIndex
+		let selectionIndex = roots.selectionIndex
 		let dummy = []
-		self.roots.addObject(dummy)
-		self.roots.removeObject(dummy)
-		self.roots.setSelectionIndex(selectionIndex)
+		roots.addObject(dummy)
+		roots.removeObject(dummy)
+		roots.setSelectionIndex(selectionIndex)
 		tableView.window?.makeFirstResponder(tableView)
 	}
 
-	@IBAction func add(sender: AnyObject) {
-		let oPanel = NSOpenPanel()
+    @IBAction func performAction(sender: NSSegmentedControl) {
+        if sender.selectedSegment == 0 {
+            let oPanel = NSOpenPanel()
 
-		oPanel.allowsMultipleSelection = true
-		oPanel.canChooseDirectories = true
-		oPanel.canChooseFiles = false
-		oPanel.treatsFilePackagesAsDirectories = true
+            oPanel.allowsMultipleSelection = true
+            oPanel.canChooseDirectories = true
+            oPanel.canChooseFiles = false
+            oPanel.treatsFilePackagesAsDirectories = true
 
-		oPanel.beginWithCompletionHandler { result in
-			if NSModalResponseOK == result {
-				self.roots.addObjects(oPanel.URLs.map { [ "Path" : $0.path!, "Languages" : true, "Architectures" : true ] })
-			}
-		}
-	}
+            oPanel.beginWithCompletionHandler { result in
+                if NSModalResponseOK == result {
+                    self.roots.addObjects(oPanel.URLs.map { [ "Path" : $0.path!, "Languages" : true, "Architectures" : true ] })
+                }
+            }
+        } else if sender.selectedSegment == 1 {
+            roots.remove(sender)
+        }
+    }
 }

--- a/Resources/Base.lproj/Main.storyboard
+++ b/Resources/Base.lproj/Main.storyboard
@@ -199,7 +199,7 @@
                                                                 <color key="gridColor" name="gridColor" catalog="System" colorSpace="catalog"/>
                                                                 <tableColumns>
                                                                     <tableColumn identifier="Remove" editable="NO" width="65" minWidth="40" maxWidth="1000" id="1XJ-Gd-jYy">
-                                                                        <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="left" title="Remove">
+                                                                        <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="center" title="Remove">
                                                                             <font key="font" metaFont="smallSystem"/>
                                                                             <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
                                                                             <color key="backgroundColor" white="0.33333298560000002" alpha="1" colorSpace="calibratedWhite"/>
@@ -209,7 +209,7 @@
                                                                             <font key="font" metaFont="titleBar" size="12"/>
                                                                         </buttonCell>
                                                                         <sortDescriptor key="sortDescriptorPrototype" selector="compare:" sortKey="enabled"/>
-                                                                        <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
+                                                                        <tableColumnResizingMask key="resizingMask" resizeWithTable="YES"/>
                                                                         <prototypeCellViews>
                                                                             <tableCellView id="Xq0-Mr-jZo">
                                                                                 <rect key="frame" x="1" y="1" width="65" height="17"/>
@@ -252,7 +252,7 @@
                                                                             <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                                                         </textFieldCell>
                                                                         <sortDescriptor key="sortDescriptorPrototype" selector="localizedCompare:" sortKey="displayName"/>
-                                                                        <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
+                                                                        <tableColumnResizingMask key="resizingMask" resizeWithTable="YES"/>
                                                                         <prototypeCellViews>
                                                                             <tableCellView id="e5v-OJ-Mpl">
                                                                                 <rect key="frame" x="69" y="1" width="279" height="17"/>
@@ -295,6 +295,9 @@
                                                         </subviews>
                                                         <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
                                                     </clipView>
+                                                    <constraints>
+                                                        <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="100" id="EzR-XE-BR7"/>
+                                                    </constraints>
                                                     <scroller key="horizontalScroller" hidden="YES" verticalHuggingPriority="750" horizontal="YES" id="ZWy-qU-g19">
                                                         <rect key="frame" x="1" y="270" width="350" height="16"/>
                                                         <autoresizingMask key="autoresizingMask"/>
@@ -353,7 +356,7 @@
                                                                 <color key="gridColor" name="gridColor" catalog="System" colorSpace="catalog"/>
                                                                 <tableColumns>
                                                                     <tableColumn identifier="Remove" editable="NO" width="65" minWidth="40" maxWidth="1000" id="pBV-1w-hWv">
-                                                                        <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="left" title="Remove">
+                                                                        <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="center" title="Remove">
                                                                             <font key="font" metaFont="smallSystem"/>
                                                                             <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
                                                                             <color key="backgroundColor" white="0.33333298560000002" alpha="1" colorSpace="calibratedWhite"/>
@@ -399,7 +402,7 @@
                                                                             <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                                                         </textFieldCell>
                                                                         <sortDescriptor key="sortDescriptorPrototype" selector="localizedCompare:" sortKey="displayName"/>
-                                                                        <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
+                                                                        <tableColumnResizingMask key="resizingMask" resizeWithTable="YES"/>
                                                                         <prototypeCellViews>
                                                                             <tableCellView id="IXo-bT-dJA">
                                                                                 <rect key="frame" x="69" y="1" width="279" height="17"/>
@@ -445,6 +448,9 @@
                                                         </subviews>
                                                         <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
                                                     </clipView>
+                                                    <constraints>
+                                                        <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="100" id="kdi-3g-50L"/>
+                                                    </constraints>
                                                     <scroller key="horizontalScroller" hidden="YES" verticalHuggingPriority="750" horizontal="YES" id="YC3-bL-1je">
                                                         <rect key="frame" x="1" y="270" width="350" height="16"/>
                                                         <autoresizingMask key="autoresizingMask"/>
@@ -562,7 +568,7 @@
             <objects>
                 <viewController storyboardIdentifier="PreferencesViewController" id="ZgY-e8-I9G" customClass="PreferencesViewController" customModule="Monolingual" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" id="zB1-iv-ycW">
-                        <rect key="frame" x="0.0" y="0.0" width="450" height="360"/>
+                        <rect key="frame" x="0.0" y="0.0" width="450" height="350"/>
                         <autoresizingMask key="autoresizingMask"/>
                         <subviews>
                             <button translatesAutoresizingMaskIntoConstraints="NO" id="de3-Hy-9QC">
@@ -586,36 +592,26 @@
                                 </connections>
                             </button>
                             <box verticalHuggingPriority="249" title="Directories:" translatesAutoresizingMaskIntoConstraints="NO" id="55G-Fd-xJZ">
-                                <rect key="frame" x="17" y="78" width="416" height="262"/>
+                                <rect key="frame" x="17" y="78" width="416" height="252"/>
                                 <view key="contentView" id="phW-MN-TLV">
-                                    <rect key="frame" x="2" y="2" width="412" height="245"/>
+                                    <rect key="frame" x="2" y="2" width="412" height="235"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
-                                        <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="N6P-44-zxI">
-                                            <rect key="frame" x="336" y="5" width="65" height="32"/>
-                                            <buttonCell key="cell" type="push" title="Add" bezelStyle="rounded" alignment="center" borderStyle="border" inset="2" id="aFz-HG-feS">
-                                                <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                                                <font key="font" metaFont="system"/>
-                                            </buttonCell>
-                                            <connections>
-                                                <action selector="add:" target="ZgY-e8-I9G" id="LtP-41-weU"/>
-                                            </connections>
-                                        </button>
                                         <scrollView autohidesScrollers="YES" horizontalLineScroll="19" horizontalPageScroll="10" verticalLineScroll="19" verticalPageScroll="10" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="tBG-2t-RdI">
-                                            <rect key="frame" x="17" y="40" width="378" height="195"/>
+                                            <rect key="frame" x="20" y="39" width="372" height="186"/>
                                             <clipView key="contentView" id="re4-3X-lnR">
-                                                <rect key="frame" x="1" y="0.0" width="376" height="194"/>
+                                                <rect key="frame" x="1" y="0.0" width="370" height="185"/>
                                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                 <subviews>
                                                     <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" alternatingRowBackgroundColors="YES" columnReordering="NO" columnSelection="YES" rowSizeStyle="automatic" headerView="xcr-EI-XkG" viewBased="YES" id="opZ-3w-oKJ">
-                                                        <rect key="frame" x="0.0" y="0.0" width="376" height="171"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="370" height="162"/>
                                                         <autoresizingMask key="autoresizingMask"/>
                                                         <size key="intercellSpacing" width="3" height="2"/>
                                                         <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
                                                         <color key="gridColor" name="gridColor" catalog="System" colorSpace="catalog"/>
                                                         <tableColumns>
                                                             <tableColumn identifier="Languages" width="74" minWidth="10" maxWidth="1000" id="weW-SY-p4l">
-                                                                <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="left" title="Languages">
+                                                                <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="center" title="Languages">
                                                                     <font key="font" metaFont="smallSystem"/>
                                                                     <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
                                                                     <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>
@@ -625,7 +621,7 @@
                                                                     <font key="font" metaFont="titleBar" size="12"/>
                                                                 </buttonCell>
                                                                 <sortDescriptor key="sortDescriptorPrototype" selector="compare:" sortKey="Languages"/>
-                                                                <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
+                                                                <tableColumnResizingMask key="resizingMask" resizeWithTable="YES"/>
                                                                 <prototypeCellViews>
                                                                     <tableCellView id="wZm-eP-xef">
                                                                         <rect key="frame" x="1" y="1" width="74" height="17"/>
@@ -651,8 +647,8 @@
                                                                 </prototypeCellViews>
                                                             </tableColumn>
                                                             <tableColumn identifier="Architectures" width="89" minWidth="31.095699310302734" maxWidth="1000" id="No6-FX-Y9X">
-                                                                <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="left" title="Architectures">
-                                                                    <font key="font" metaFont="smallSystem"/>
+                                                                <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="center" title="Architectures">
+                                                                    <font key="font" metaFont="systemMedium" size="11"/>
                                                                     <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
                                                                     <color key="backgroundColor" white="0.33333298560000002" alpha="1" colorSpace="calibratedWhite"/>
                                                                 </tableHeaderCell>
@@ -661,7 +657,7 @@
                                                                     <font key="font" metaFont="smallSystem"/>
                                                                 </buttonCell>
                                                                 <sortDescriptor key="sortDescriptorPrototype" selector="compare:" sortKey="Architectures"/>
-                                                                <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
+                                                                <tableColumnResizingMask key="resizingMask" resizeWithTable="YES"/>
                                                                 <prototypeCellViews>
                                                                     <tableCellView id="rsx-mP-b9k">
                                                                         <rect key="frame" x="78" y="1" width="89" height="17"/>
@@ -686,7 +682,7 @@
                                                                     </tableCellView>
                                                                 </prototypeCellViews>
                                                             </tableColumn>
-                                                            <tableColumn identifier="Path" editable="NO" width="204" minWidth="10" maxWidth="3.4028230607370965e+38" id="OFP-Qj-bkb">
+                                                            <tableColumn identifier="Path" editable="NO" width="198" minWidth="10" maxWidth="3.4028230607370965e+38" id="OFP-Qj-bkb">
                                                                 <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="left" title="Path">
                                                                     <font key="font" metaFont="smallSystem"/>
                                                                     <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
@@ -698,14 +694,14 @@
                                                                     <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
                                                                 </textFieldCell>
                                                                 <sortDescriptor key="sortDescriptorPrototype" selector="localizedCompare:" sortKey="Path"/>
-                                                                <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
+                                                                <tableColumnResizingMask key="resizingMask" resizeWithTable="YES"/>
                                                                 <prototypeCellViews>
                                                                     <tableCellView id="a8l-8R-7ag">
-                                                                        <rect key="frame" x="170" y="1" width="204" height="17"/>
+                                                                        <rect key="frame" x="170" y="1" width="198" height="17"/>
                                                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                                         <subviews>
                                                                             <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Sih-z2-NiO">
-                                                                                <rect key="frame" x="0.0" y="0.0" width="186" height="17"/>
+                                                                                <rect key="frame" x="0.0" y="0.0" width="197" height="17"/>
                                                                                 <textFieldCell key="cell" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" usesSingleLineMode="YES" id="F34-1y-CM7">
                                                                                     <font key="font" metaFont="system"/>
                                                                                     <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
@@ -719,7 +715,7 @@
                                                                         <constraints>
                                                                             <constraint firstAttribute="centerY" secondItem="Sih-z2-NiO" secondAttribute="centerY" id="442-Gr-I6q"/>
                                                                             <constraint firstItem="Sih-z2-NiO" firstAttribute="leading" secondItem="a8l-8R-7ag" secondAttribute="leading" constant="2" id="AKv-Ob-DBb"/>
-                                                                            <constraint firstAttribute="trailing" secondItem="Sih-z2-NiO" secondAttribute="trailing" constant="20" symbolic="YES" id="ocU-Xi-e9s"/>
+                                                                            <constraint firstAttribute="trailing" secondItem="Sih-z2-NiO" secondAttribute="trailing" constant="3" id="ocU-Xi-e9s"/>
                                                                         </constraints>
                                                                     </tableCellView>
                                                                 </prototypeCellViews>
@@ -734,7 +730,10 @@
                                                 </subviews>
                                                 <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
                                             </clipView>
-                                            <scroller key="horizontalScroller" hidden="YES" verticalHuggingPriority="750" doubleValue="0.5" horizontal="YES" id="fP9-C9-7Cv">
+                                            <constraints>
+                                                <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="100" id="ib0-dL-oGb"/>
+                                            </constraints>
+                                            <scroller key="horizontalScroller" hidden="YES" verticalHuggingPriority="750" horizontal="YES" id="fP9-C9-7Cv">
                                                 <rect key="frame" x="1" y="114" width="355" height="15"/>
                                                 <autoresizingMask key="autoresizingMask"/>
                                             </scroller>
@@ -743,37 +742,41 @@
                                                 <autoresizingMask key="autoresizingMask"/>
                                             </scroller>
                                             <tableHeaderView key="headerView" id="xcr-EI-XkG">
-                                                <rect key="frame" x="0.0" y="0.0" width="376" height="23"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="370" height="23"/>
                                                 <autoresizingMask key="autoresizingMask"/>
                                             </tableHeaderView>
                                         </scrollView>
-                                        <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="txs-gW-YkQ">
-                                            <rect key="frame" x="247" y="5" width="89" height="32"/>
-                                            <buttonCell key="cell" type="push" title="Remove" bezelStyle="rounded" alignment="center" borderStyle="border" inset="2" id="iw9-pP-alf">
-                                                <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                                        <segmentedControl verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="fbf-bv-ZvL">
+                                            <rect key="frame" x="18" y="8" width="55" height="24"/>
+                                            <segmentedCell key="cell" borderStyle="border" alignment="left" style="rounded" trackingMode="momentary" id="hCz-Dk-15A">
                                                 <font key="font" metaFont="system"/>
-                                            </buttonCell>
+                                                <segments>
+                                                    <segment image="NSAddTemplate" width="24">
+                                                        <nil key="label"/>
+                                                    </segment>
+                                                    <segment image="NSRemoveTemplate" width="24" tag="1">
+                                                        <nil key="label"/>
+                                                    </segment>
+                                                </segments>
+                                            </segmentedCell>
                                             <connections>
-                                                <action selector="remove:" target="NZ6-CJ-opI" id="lA5-09-A0V"/>
+                                                <action selector="performAction:" target="ZgY-e8-I9G" id="c1y-bX-CAF"/>
                                             </connections>
-                                        </button>
+                                        </segmentedControl>
                                     </subviews>
                                     <constraints>
                                         <constraint firstItem="tBG-2t-RdI" firstAttribute="top" secondItem="phW-MN-TLV" secondAttribute="top" constant="10" id="7ux-Ce-nHb"/>
+                                        <constraint firstItem="fbf-bv-ZvL" firstAttribute="leading" secondItem="phW-MN-TLV" secondAttribute="leading" constant="20" id="LbX-au-Tbp"/>
+                                        <constraint firstAttribute="bottom" secondItem="fbf-bv-ZvL" secondAttribute="bottom" constant="10" id="aue-Eq-9fU"/>
+                                        <constraint firstAttribute="bottom" secondItem="tBG-2t-RdI" secondAttribute="bottom" constant="39" id="hfG-gs-4Df"/>
                                     </constraints>
                                 </view>
                                 <constraints>
-                                    <constraint firstAttribute="trailing" secondItem="N6P-44-zxI" secondAttribute="trailing" constant="16" id="63x-FZ-pNG"/>
-                                    <constraint firstItem="txs-gW-YkQ" firstAttribute="centerY" secondItem="N6P-44-zxI" secondAttribute="centerY" id="A9G-4l-PMV"/>
-                                    <constraint firstItem="N6P-44-zxI" firstAttribute="top" secondItem="tBG-2t-RdI" secondAttribute="bottom" constant="7" id="OGl-Iv-8aS"/>
-                                    <constraint firstAttribute="trailing" secondItem="tBG-2t-RdI" secondAttribute="trailing" constant="16" id="ZyL-iN-m5f"/>
-                                    <constraint firstItem="N6P-44-zxI" firstAttribute="leading" secondItem="txs-gW-YkQ" secondAttribute="trailing" constant="12" id="jza-hq-NLT"/>
-                                    <constraint firstAttribute="bottom" secondItem="N6P-44-zxI" secondAttribute="bottom" constant="10" id="mnc-e4-ruQ"/>
-                                    <constraint firstItem="tBG-2t-RdI" firstAttribute="leading" secondItem="55G-Fd-xJZ" secondAttribute="leading" constant="16" id="oga-4M-VpF"/>
+                                    <constraint firstAttribute="trailing" secondItem="tBG-2t-RdI" secondAttribute="trailing" constant="19" id="ZyL-iN-m5f"/>
+                                    <constraint firstItem="tBG-2t-RdI" firstAttribute="leading" secondItem="55G-Fd-xJZ" secondAttribute="leading" constant="19" id="oga-4M-VpF"/>
                                 </constraints>
                                 <color key="borderColor" white="0.0" alpha="0.41999999999999998" colorSpace="calibratedWhite"/>
                                 <color key="fillColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
-                                <font key="titleFont" metaFont="message" size="11"/>
                             </box>
                             <button translatesAutoresizingMaskIntoConstraints="NO" id="EUm-lj-8tR">
                                 <rect key="frame" x="18" y="18" width="414" height="18"/>
@@ -824,7 +827,7 @@
                 </arrayController>
                 <userDefaultsController representsSharedInstance="YES" id="4nR-6U-bWS"/>
             </objects>
-            <point key="canvasLocation" x="607" y="805"/>
+            <point key="canvasLocation" x="607" y="800"/>
         </scene>
         <!--Progress View Controller-->
         <scene sceneID="uF6-Yw-Nyd">
@@ -893,4 +896,8 @@
             <point key="canvasLocation" x="1286" y="695.5"/>
         </scene>
     </scenes>
+    <resources>
+        <image name="NSAddTemplate" width="11" height="11"/>
+        <image name="NSRemoveTemplate" width="11" height="11"/>
+    </resources>
 </document>

--- a/Resources/Base.lproj/Main.storyboard
+++ b/Resources/Base.lproj/Main.storyboard
@@ -168,31 +168,23 @@
                         <rect key="frame" x="0.0" y="0.0" width="429" height="429"/>
                         <autoresizingMask key="autoresizingMask"/>
                         <subviews>
-                            <textField verticalHuggingPriority="750" setsMaxLayoutWidthAtFirstLayout="YES" translatesAutoresizingMaskIntoConstraints="NO" id="r1H-q7-SOJ">
-                                <rect key="frame" x="18" y="392" width="393" height="17"/>
-                                <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="left" title="Select the items you wish to remove:" usesSingleLineMode="YES" id="z6z-xJ-Pjk">
-                                    <font key="font" metaFont="system"/>
-                                    <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                    <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                </textFieldCell>
-                            </textField>
                             <tabView translatesAutoresizingMaskIntoConstraints="NO" id="3Kl-1z-1DJ">
-                                <rect key="frame" x="11" y="10" width="406" height="380"/>
+                                <rect key="frame" x="11" y="10" width="406" height="413"/>
                                 <font key="font" metaFont="system"/>
                                 <tabViewItems>
                                     <tabViewItem label="Languages" identifier="1" id="bcK-xR-VFN">
                                         <view key="view" id="YBY-Bn-MZl">
-                                            <rect key="frame" x="10" y="33" width="386" height="334"/>
+                                            <rect key="frame" x="10" y="33" width="386" height="367"/>
                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                             <subviews>
                                                 <scrollView autohidesScrollers="YES" horizontalLineScroll="19" horizontalPageScroll="10" verticalLineScroll="19" verticalPageScroll="10" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="BOy-QX-NcS">
-                                                    <rect key="frame" x="17" y="58" width="352" height="273"/>
+                                                    <rect key="frame" x="17" y="58" width="352" height="281"/>
                                                     <clipView key="contentView" id="OFF-NN-dqj">
-                                                        <rect key="frame" x="1" y="0.0" width="350" height="272"/>
+                                                        <rect key="frame" x="1" y="0.0" width="350" height="280"/>
                                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                         <subviews>
                                                             <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" alternatingRowBackgroundColors="YES" columnReordering="NO" multipleSelection="NO" autosaveColumns="NO" rowSizeStyle="automatic" headerView="XJy-gd-pmN" viewBased="YES" id="QaX-Sy-Spj" customClass="ISTableView" customModule="Monolingual" customModuleProvider="target">
-                                                                <rect key="frame" x="0.0" y="0.0" width="350" height="249"/>
+                                                                <rect key="frame" x="0.0" y="0.0" width="350" height="257"/>
                                                                 <autoresizingMask key="autoresizingMask"/>
                                                                 <size key="intercellSpacing" width="3" height="2"/>
                                                                 <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
@@ -326,30 +318,41 @@
                                                         <outlet property="nextKeyView" destination="3Kl-1z-1DJ" id="d5h-ax-eSV"/>
                                                     </connections>
                                                 </button>
+                                                <textField verticalHuggingPriority="750" setsMaxLayoutWidthAtFirstLayout="YES" translatesAutoresizingMaskIntoConstraints="NO" id="r1H-q7-SOJ">
+                                                    <rect key="frame" x="15" y="347" width="356" height="17"/>
+                                                    <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="left" title="Select the items you wish to remove:" usesSingleLineMode="YES" id="z6z-xJ-Pjk">
+                                                        <font key="font" metaFont="system"/>
+                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                    </textFieldCell>
+                                                </textField>
                                             </subviews>
                                             <constraints>
                                                 <constraint firstAttribute="bottom" secondItem="BOy-QX-NcS" secondAttribute="bottom" constant="58" id="1Bx-8z-jAr"/>
+                                                <constraint firstItem="BOy-QX-NcS" firstAttribute="top" secondItem="r1H-q7-SOJ" secondAttribute="bottom" constant="8" id="3AD-Ua-Dn6"/>
                                                 <constraint firstAttribute="trailing" secondItem="0Gf-z3-wgw" secondAttribute="trailing" constant="17" id="5C0-mb-lBW"/>
+                                                <constraint firstAttribute="trailing" secondItem="r1H-q7-SOJ" secondAttribute="trailing" constant="17" id="BXo-hP-dpq"/>
                                                 <constraint firstAttribute="trailing" secondItem="BOy-QX-NcS" secondAttribute="trailing" constant="17" id="Fuj-V7-rxj"/>
                                                 <constraint firstAttribute="bottom" secondItem="0Gf-z3-wgw" secondAttribute="bottom" constant="17" id="IxR-HV-6f0"/>
                                                 <constraint firstItem="BOy-QX-NcS" firstAttribute="leading" secondItem="YBY-Bn-MZl" secondAttribute="leading" constant="17" id="Xup-Hm-CeS"/>
-                                                <constraint firstItem="BOy-QX-NcS" firstAttribute="top" secondItem="YBY-Bn-MZl" secondAttribute="top" constant="3" id="ij3-NQ-m1K"/>
+                                                <constraint firstItem="r1H-q7-SOJ" firstAttribute="leading" secondItem="YBY-Bn-MZl" secondAttribute="leading" constant="17" id="tz0-2g-dht"/>
+                                                <constraint firstItem="r1H-q7-SOJ" firstAttribute="top" secondItem="YBY-Bn-MZl" secondAttribute="top" constant="3" id="ziX-ZC-sfB"/>
                                             </constraints>
                                         </view>
                                     </tabViewItem>
                                     <tabViewItem label="Architectures" identifier="" id="CxN-75-fAV">
                                         <view key="view" id="iOc-2Z-Ipp">
-                                            <rect key="frame" x="10" y="33" width="386" height="334"/>
+                                            <rect key="frame" x="10" y="33" width="386" height="367"/>
                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                             <subviews>
                                                 <scrollView autohidesScrollers="YES" horizontalLineScroll="19" horizontalPageScroll="10" verticalLineScroll="19" verticalPageScroll="10" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="MvI-uV-IhN">
-                                                    <rect key="frame" x="17" y="58" width="352" height="273"/>
+                                                    <rect key="frame" x="17" y="58" width="352" height="281"/>
                                                     <clipView key="contentView" id="SKk-Kv-SfJ">
-                                                        <rect key="frame" x="1" y="0.0" width="350" height="272"/>
+                                                        <rect key="frame" x="1" y="0.0" width="350" height="280"/>
                                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                         <subviews>
                                                             <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" alternatingRowBackgroundColors="YES" columnReordering="NO" multipleSelection="NO" autosaveColumns="NO" rowSizeStyle="automatic" headerView="NlO-4R-8fn" viewBased="YES" id="oIA-xq-q0B" customClass="ISTableView" customModule="Monolingual" customModuleProvider="target">
-                                                                <rect key="frame" x="0.0" y="0.0" width="350" height="249"/>
+                                                                <rect key="frame" x="0.0" y="0.0" width="350" height="257"/>
                                                                 <autoresizingMask key="autoresizingMask"/>
                                                                 <size key="intercellSpacing" width="3" height="2"/>
                                                                 <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
@@ -487,13 +490,24 @@
                                                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                     </textFieldCell>
                                                 </textField>
+                                                <textField verticalHuggingPriority="750" setsMaxLayoutWidthAtFirstLayout="YES" translatesAutoresizingMaskIntoConstraints="NO" id="p44-8u-umj">
+                                                    <rect key="frame" x="15" y="347" width="356" height="17"/>
+                                                    <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="left" title="Select the items you wish to remove:" usesSingleLineMode="YES" id="4Es-9R-gAn">
+                                                        <font key="font" metaFont="system"/>
+                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                    </textFieldCell>
+                                                </textField>
                                             </subviews>
                                             <constraints>
-                                                <constraint firstItem="MvI-uV-IhN" firstAttribute="top" secondItem="iOc-2Z-Ipp" secondAttribute="top" constant="3" id="0VC-Fx-FvK"/>
                                                 <constraint firstAttribute="trailing" secondItem="MvI-uV-IhN" secondAttribute="trailing" constant="17" id="Cd4-em-1dk"/>
+                                                <constraint firstAttribute="trailing" secondItem="p44-8u-umj" secondAttribute="trailing" constant="17" id="LxC-EG-jm1"/>
                                                 <constraint firstItem="65V-iD-EUO" firstAttribute="leading" secondItem="HY1-Mt-SGD" secondAttribute="trailing" constant="8" id="MYE-Qu-fmO"/>
+                                                <constraint firstItem="MvI-uV-IhN" firstAttribute="top" secondItem="p44-8u-umj" secondAttribute="bottom" constant="8" id="Q7g-Ez-gfa"/>
+                                                <constraint firstItem="p44-8u-umj" firstAttribute="top" secondItem="iOc-2Z-Ipp" secondAttribute="top" constant="3" id="Zwk-Jc-3KA"/>
                                                 <constraint firstItem="HY1-Mt-SGD" firstAttribute="baseline" secondItem="65V-iD-EUO" secondAttribute="baseline" id="ad2-R5-1Mu"/>
                                                 <constraint firstAttribute="trailing" secondItem="65V-iD-EUO" secondAttribute="trailing" constant="17" id="caA-GF-CLp"/>
+                                                <constraint firstItem="p44-8u-umj" firstAttribute="leading" secondItem="iOc-2Z-Ipp" secondAttribute="leading" constant="17" id="cc5-fD-kg3"/>
                                                 <constraint firstItem="MvI-uV-IhN" firstAttribute="leading" secondItem="iOc-2Z-Ipp" secondAttribute="leading" constant="17" id="hln-Qp-e4J"/>
                                                 <constraint firstItem="HY1-Mt-SGD" firstAttribute="leading" secondItem="iOc-2Z-Ipp" secondAttribute="leading" constant="17" id="oCl-1y-ZMl"/>
                                                 <constraint firstAttribute="bottom" secondItem="MvI-uV-IhN" secondAttribute="bottom" constant="58" id="uhc-Uu-fa3"/>
@@ -505,13 +519,10 @@
                             </tabView>
                         </subviews>
                         <constraints>
-                            <constraint firstItem="r1H-q7-SOJ" firstAttribute="leading" secondItem="m2S-Jp-Qdl" secondAttribute="leading" constant="20" symbolic="YES" id="0Nu-P5-8ic"/>
                             <constraint firstAttribute="bottom" secondItem="3Kl-1z-1DJ" secondAttribute="bottom" constant="20" id="F26-Yx-RGK"/>
                             <constraint firstItem="3Kl-1z-1DJ" firstAttribute="leading" secondItem="m2S-Jp-Qdl" secondAttribute="leading" constant="18" id="FQb-Rs-UL1"/>
                             <constraint firstAttribute="trailing" secondItem="3Kl-1z-1DJ" secondAttribute="trailing" constant="19" id="G7G-nv-rnW"/>
-                            <constraint firstItem="3Kl-1z-1DJ" firstAttribute="top" secondItem="r1H-q7-SOJ" secondAttribute="bottom" constant="8" id="USV-dL-gOF"/>
-                            <constraint firstItem="r1H-q7-SOJ" firstAttribute="top" secondItem="m2S-Jp-Qdl" secondAttribute="top" constant="20" symbolic="YES" id="qnZ-Th-qrQ"/>
-                            <constraint firstAttribute="trailing" secondItem="r1H-q7-SOJ" secondAttribute="trailing" constant="20" symbolic="YES" id="t85-wT-n6g"/>
+                            <constraint firstItem="3Kl-1z-1DJ" firstAttribute="top" secondItem="m2S-Jp-Qdl" secondAttribute="top" constant="12" id="myN-5L-qzn"/>
                         </constraints>
                     </view>
                     <connections>

--- a/Resources/Base.lproj/Main.storyboard
+++ b/Resources/Base.lproj/Main.storyboard
@@ -312,8 +312,8 @@
                                                     </connections>
                                                 </scrollView>
                                                 <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="0Gf-z3-wgw">
-                                                    <rect key="frame" x="286" y="10" width="89" height="32"/>
-                                                    <buttonCell key="cell" type="push" title="Remove" bezelStyle="rounded" alignment="center" borderStyle="border" inset="2" id="7bE-Hh-5SU">
+                                                    <rect key="frame" x="276" y="10" width="99" height="32"/>
+                                                    <buttonCell key="cell" type="push" title="Remove…" bezelStyle="rounded" alignment="center" borderStyle="border" inset="2" id="7bE-Hh-5SU">
                                                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                                         <font key="font" metaFont="system"/>
                                                         <string key="keyEquivalent"></string>
@@ -462,8 +462,8 @@
                                                     </connections>
                                                 </scrollView>
                                                 <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="65V-iD-EUO">
-                                                    <rect key="frame" x="286" y="10" width="89" height="32"/>
-                                                    <buttonCell key="cell" type="push" title="Remove" bezelStyle="rounded" alignment="center" borderStyle="border" inset="2" id="oQU-Vk-TEO">
+                                                    <rect key="frame" x="276" y="10" width="99" height="32"/>
+                                                    <buttonCell key="cell" type="push" title="Remove…" bezelStyle="rounded" alignment="center" borderStyle="border" inset="2" id="oQU-Vk-TEO">
                                                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                                         <font key="font" metaFont="system"/>
                                                         <string key="keyEquivalent"></string>
@@ -474,7 +474,7 @@
                                                     </connections>
                                                 </button>
                                                 <textField horizontalHuggingPriority="249" verticalHuggingPriority="750" setsMaxLayoutWidthAtFirstLayout="YES" translatesAutoresizingMaskIntoConstraints="NO" id="HY1-Mt-SGD">
-                                                    <rect key="frame" x="15" y="20" width="268" height="14"/>
+                                                    <rect key="frame" x="15" y="20" width="261" height="14"/>
                                                     <textFieldCell key="cell" sendsActionOnEndEditing="YES" title="Current architecture: %@" id="yB7-o0-eDt">
                                                         <font key="font" metaFont="smallSystem"/>
                                                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -485,7 +485,7 @@
                                             <constraints>
                                                 <constraint firstItem="MvI-uV-IhN" firstAttribute="top" secondItem="iOc-2Z-Ipp" secondAttribute="top" constant="3" id="0VC-Fx-FvK"/>
                                                 <constraint firstAttribute="trailing" secondItem="MvI-uV-IhN" secondAttribute="trailing" constant="17" id="Cd4-em-1dk"/>
-                                                <constraint firstItem="65V-iD-EUO" firstAttribute="leading" secondItem="HY1-Mt-SGD" secondAttribute="trailing" constant="11" id="MYE-Qu-fmO"/>
+                                                <constraint firstItem="65V-iD-EUO" firstAttribute="leading" secondItem="HY1-Mt-SGD" secondAttribute="trailing" constant="8" id="MYE-Qu-fmO"/>
                                                 <constraint firstItem="HY1-Mt-SGD" firstAttribute="baseline" secondItem="65V-iD-EUO" secondAttribute="baseline" id="ad2-R5-1Mu"/>
                                                 <constraint firstAttribute="trailing" secondItem="65V-iD-EUO" secondAttribute="trailing" constant="17" id="caA-GF-CLp"/>
                                                 <constraint firstItem="MvI-uV-IhN" firstAttribute="leading" secondItem="iOc-2Z-Ipp" secondAttribute="leading" constant="17" id="hln-Qp-e4J"/>

--- a/Resources/Base.lproj/Main.storyboard
+++ b/Resources/Base.lproj/Main.storyboard
@@ -185,14 +185,14 @@
                                             <rect key="frame" x="10" y="33" width="386" height="334"/>
                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                             <subviews>
-                                                <scrollView horizontalLineScroll="19" horizontalPageScroll="10" verticalLineScroll="19" verticalPageScroll="10" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="BOy-QX-NcS">
-                                                    <rect key="frame" x="20" y="57" width="346" height="277"/>
+                                                <scrollView autohidesScrollers="YES" horizontalLineScroll="19" horizontalPageScroll="10" verticalLineScroll="19" verticalPageScroll="10" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="BOy-QX-NcS">
+                                                    <rect key="frame" x="17" y="58" width="352" height="273"/>
                                                     <clipView key="contentView" id="OFF-NN-dqj">
-                                                        <rect key="frame" x="1" y="0.0" width="344" height="276"/>
+                                                        <rect key="frame" x="1" y="0.0" width="350" height="272"/>
                                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                         <subviews>
                                                             <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" alternatingRowBackgroundColors="YES" columnReordering="NO" multipleSelection="NO" autosaveColumns="NO" rowSizeStyle="automatic" headerView="XJy-gd-pmN" viewBased="YES" id="QaX-Sy-Spj" customClass="ISTableView" customModule="Monolingual" customModuleProvider="target">
-                                                                <rect key="frame" x="0.0" y="0.0" width="344" height="253"/>
+                                                                <rect key="frame" x="0.0" y="0.0" width="350" height="249"/>
                                                                 <autoresizingMask key="autoresizingMask"/>
                                                                 <size key="intercellSpacing" width="3" height="2"/>
                                                                 <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
@@ -240,7 +240,7 @@
                                                                             </binding>
                                                                         </connections>
                                                                     </tableColumn>
-                                                                    <tableColumn identifier="Name" editable="NO" width="273.01416015625" minWidth="59.51416015625" maxWidth="1000" id="XXG-zZ-uSC">
+                                                                    <tableColumn identifier="Name" editable="NO" width="279.01416015625" minWidth="59.51416015625" maxWidth="1000" id="XXG-zZ-uSC">
                                                                         <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="left" title="Language">
                                                                             <font key="font" metaFont="smallSystem"/>
                                                                             <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
@@ -255,11 +255,11 @@
                                                                         <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
                                                                         <prototypeCellViews>
                                                                             <tableCellView id="e5v-OJ-Mpl">
-                                                                                <rect key="frame" x="69" y="1" width="273" height="17"/>
+                                                                                <rect key="frame" x="69" y="1" width="279" height="17"/>
                                                                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                                                 <subviews>
                                                                                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="RhH-ee-Nwb">
-                                                                                        <rect key="frame" x="2" y="0.0" width="253" height="17"/>
+                                                                                        <rect key="frame" x="2" y="0.0" width="276" height="17"/>
                                                                                         <textFieldCell key="cell" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" state="on" id="OE1-nl-2Y2">
                                                                                             <font key="font" metaFont="system"/>
                                                                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -273,7 +273,7 @@
                                                                                 <constraints>
                                                                                     <constraint firstAttribute="centerY" secondItem="RhH-ee-Nwb" secondAttribute="centerY" id="bit-Yr-VWv"/>
                                                                                     <constraint firstItem="RhH-ee-Nwb" firstAttribute="leading" secondItem="e5v-OJ-Mpl" secondAttribute="leading" constant="4" id="h4a-o4-RkO"/>
-                                                                                    <constraint firstAttribute="trailing" secondItem="RhH-ee-Nwb" secondAttribute="trailing" constant="20" symbolic="YES" id="sfQ-QQ-bQP"/>
+                                                                                    <constraint firstAttribute="trailing" secondItem="RhH-ee-Nwb" secondAttribute="trailing" constant="3" id="sfQ-QQ-bQP"/>
                                                                                 </constraints>
                                                                             </tableCellView>
                                                                         </prototypeCellViews>
@@ -295,16 +295,16 @@
                                                         </subviews>
                                                         <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
                                                     </clipView>
-                                                    <scroller key="horizontalScroller" verticalHuggingPriority="750" horizontal="YES" id="ZWy-qU-g19">
-                                                        <rect key="frame" x="1" y="260" width="344" height="16"/>
+                                                    <scroller key="horizontalScroller" hidden="YES" verticalHuggingPriority="750" horizontal="YES" id="ZWy-qU-g19">
+                                                        <rect key="frame" x="1" y="270" width="350" height="16"/>
                                                         <autoresizingMask key="autoresizingMask"/>
                                                     </scroller>
-                                                    <scroller key="verticalScroller" verticalHuggingPriority="750" horizontal="NO" id="ojR-eS-P1m">
-                                                        <rect key="frame" x="330" y="23" width="15" height="253"/>
+                                                    <scroller key="verticalScroller" hidden="YES" verticalHuggingPriority="750" horizontal="NO" id="ojR-eS-P1m">
+                                                        <rect key="frame" x="335" y="23" width="16" height="263"/>
                                                         <autoresizingMask key="autoresizingMask"/>
                                                     </scroller>
                                                     <tableHeaderView key="headerView" id="XJy-gd-pmN">
-                                                        <rect key="frame" x="0.0" y="0.0" width="344" height="23"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="350" height="23"/>
                                                         <autoresizingMask key="autoresizingMask"/>
                                                     </tableHeaderView>
                                                     <connections>
@@ -312,7 +312,7 @@
                                                     </connections>
                                                 </scrollView>
                                                 <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="0Gf-z3-wgw">
-                                                    <rect key="frame" x="283" y="9" width="89" height="32"/>
+                                                    <rect key="frame" x="286" y="10" width="89" height="32"/>
                                                     <buttonCell key="cell" type="push" title="Remove" bezelStyle="rounded" alignment="center" borderStyle="border" inset="2" id="7bE-Hh-5SU">
                                                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                                         <font key="font" metaFont="system"/>
@@ -325,12 +325,12 @@
                                                 </button>
                                             </subviews>
                                             <constraints>
-                                                <constraint firstAttribute="bottom" secondItem="BOy-QX-NcS" secondAttribute="bottom" constant="57" id="1Bx-8z-jAr"/>
-                                                <constraint firstAttribute="trailing" secondItem="0Gf-z3-wgw" secondAttribute="trailing" constant="20" id="5C0-mb-lBW"/>
-                                                <constraint firstAttribute="trailing" secondItem="BOy-QX-NcS" secondAttribute="trailing" constant="20" id="Fuj-V7-rxj"/>
-                                                <constraint firstAttribute="bottom" secondItem="0Gf-z3-wgw" secondAttribute="bottom" constant="16" id="IxR-HV-6f0"/>
-                                                <constraint firstItem="BOy-QX-NcS" firstAttribute="leading" secondItem="YBY-Bn-MZl" secondAttribute="leading" constant="20" id="Xup-Hm-CeS"/>
-                                                <constraint firstItem="BOy-QX-NcS" firstAttribute="top" secondItem="YBY-Bn-MZl" secondAttribute="top" id="ij3-NQ-m1K"/>
+                                                <constraint firstAttribute="bottom" secondItem="BOy-QX-NcS" secondAttribute="bottom" constant="58" id="1Bx-8z-jAr"/>
+                                                <constraint firstAttribute="trailing" secondItem="0Gf-z3-wgw" secondAttribute="trailing" constant="17" id="5C0-mb-lBW"/>
+                                                <constraint firstAttribute="trailing" secondItem="BOy-QX-NcS" secondAttribute="trailing" constant="17" id="Fuj-V7-rxj"/>
+                                                <constraint firstAttribute="bottom" secondItem="0Gf-z3-wgw" secondAttribute="bottom" constant="17" id="IxR-HV-6f0"/>
+                                                <constraint firstItem="BOy-QX-NcS" firstAttribute="leading" secondItem="YBY-Bn-MZl" secondAttribute="leading" constant="17" id="Xup-Hm-CeS"/>
+                                                <constraint firstItem="BOy-QX-NcS" firstAttribute="top" secondItem="YBY-Bn-MZl" secondAttribute="top" constant="3" id="ij3-NQ-m1K"/>
                                             </constraints>
                                         </view>
                                     </tabViewItem>
@@ -339,14 +339,14 @@
                                             <rect key="frame" x="10" y="33" width="386" height="334"/>
                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                             <subviews>
-                                                <scrollView horizontalLineScroll="19" horizontalPageScroll="10" verticalLineScroll="19" verticalPageScroll="10" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="MvI-uV-IhN">
-                                                    <rect key="frame" x="20" y="57" width="346" height="277"/>
+                                                <scrollView autohidesScrollers="YES" horizontalLineScroll="19" horizontalPageScroll="10" verticalLineScroll="19" verticalPageScroll="10" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="MvI-uV-IhN">
+                                                    <rect key="frame" x="17" y="58" width="352" height="273"/>
                                                     <clipView key="contentView" id="SKk-Kv-SfJ">
-                                                        <rect key="frame" x="1" y="0.0" width="344" height="276"/>
+                                                        <rect key="frame" x="1" y="0.0" width="350" height="272"/>
                                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                         <subviews>
                                                             <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" alternatingRowBackgroundColors="YES" columnReordering="NO" multipleSelection="NO" autosaveColumns="NO" rowSizeStyle="automatic" headerView="NlO-4R-8fn" viewBased="YES" id="oIA-xq-q0B" customClass="ISTableView" customModule="Monolingual" customModuleProvider="target">
-                                                                <rect key="frame" x="0.0" y="0.0" width="344" height="253"/>
+                                                                <rect key="frame" x="0.0" y="0.0" width="350" height="249"/>
                                                                 <autoresizingMask key="autoresizingMask"/>
                                                                 <size key="intercellSpacing" width="3" height="2"/>
                                                                 <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
@@ -363,7 +363,7 @@
                                                                             <font key="font" metaFont="titleBar" size="12"/>
                                                                         </buttonCell>
                                                                         <sortDescriptor key="sortDescriptorPrototype" selector="compare:" sortKey="enabled"/>
-                                                                        <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
+                                                                        <tableColumnResizingMask key="resizingMask" resizeWithTable="YES"/>
                                                                         <prototypeCellViews>
                                                                             <tableCellView id="frg-uD-vBQ">
                                                                                 <rect key="frame" x="1" y="1" width="65" height="17"/>
@@ -387,7 +387,7 @@
                                                                             </tableCellView>
                                                                         </prototypeCellViews>
                                                                     </tableColumn>
-                                                                    <tableColumn identifier="Name" editable="NO" width="273.17822265625" minWidth="73.17822265625" maxWidth="1000" id="5qX-Sa-tJD">
+                                                                    <tableColumn identifier="Name" editable="NO" width="279.17822265625" minWidth="73.17822265625" maxWidth="1000" id="5qX-Sa-tJD">
                                                                         <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="left" title="Architecture">
                                                                             <font key="font" metaFont="smallSystem"/>
                                                                             <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
@@ -402,11 +402,11 @@
                                                                         <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
                                                                         <prototypeCellViews>
                                                                             <tableCellView id="IXo-bT-dJA">
-                                                                                <rect key="frame" x="69" y="1" width="273" height="17"/>
+                                                                                <rect key="frame" x="69" y="1" width="279" height="17"/>
                                                                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                                                 <subviews>
                                                                                     <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="pWo-oD-xuT">
-                                                                                        <rect key="frame" x="2" y="0.0" width="253" height="17"/>
+                                                                                        <rect key="frame" x="2" y="0.0" width="276" height="17"/>
                                                                                         <textFieldCell key="cell" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" id="yiF-fN-fVE">
                                                                                             <font key="font" metaFont="system"/>
                                                                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -419,7 +419,7 @@
                                                                                 </subviews>
                                                                                 <constraints>
                                                                                     <constraint firstItem="pWo-oD-xuT" firstAttribute="leading" secondItem="IXo-bT-dJA" secondAttribute="leading" constant="4" id="5Cr-7a-qF9"/>
-                                                                                    <constraint firstAttribute="trailing" secondItem="pWo-oD-xuT" secondAttribute="trailing" constant="20" symbolic="YES" id="gfD-GC-N5R"/>
+                                                                                    <constraint firstAttribute="trailing" secondItem="pWo-oD-xuT" secondAttribute="trailing" constant="3" id="gfD-GC-N5R"/>
                                                                                     <constraint firstAttribute="centerY" secondItem="pWo-oD-xuT" secondAttribute="centerY" id="oEY-tc-YY4"/>
                                                                                 </constraints>
                                                                                 <connections>
@@ -445,16 +445,16 @@
                                                         </subviews>
                                                         <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
                                                     </clipView>
-                                                    <scroller key="horizontalScroller" verticalHuggingPriority="750" horizontal="YES" id="YC3-bL-1je">
-                                                        <rect key="frame" x="1" y="260" width="344" height="16"/>
+                                                    <scroller key="horizontalScroller" hidden="YES" verticalHuggingPriority="750" horizontal="YES" id="YC3-bL-1je">
+                                                        <rect key="frame" x="1" y="270" width="350" height="16"/>
                                                         <autoresizingMask key="autoresizingMask"/>
                                                     </scroller>
-                                                    <scroller key="verticalScroller" verticalHuggingPriority="750" horizontal="NO" id="OqA-Jo-yiV">
-                                                        <rect key="frame" x="330" y="23" width="15" height="253"/>
+                                                    <scroller key="verticalScroller" hidden="YES" verticalHuggingPriority="750" horizontal="NO" id="OqA-Jo-yiV">
+                                                        <rect key="frame" x="335" y="23" width="16" height="263"/>
                                                         <autoresizingMask key="autoresizingMask"/>
                                                     </scroller>
                                                     <tableHeaderView key="headerView" id="NlO-4R-8fn">
-                                                        <rect key="frame" x="0.0" y="0.0" width="344" height="23"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="350" height="23"/>
                                                         <autoresizingMask key="autoresizingMask"/>
                                                     </tableHeaderView>
                                                     <connections>
@@ -462,7 +462,7 @@
                                                     </connections>
                                                 </scrollView>
                                                 <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="65V-iD-EUO">
-                                                    <rect key="frame" x="283" y="9" width="89" height="32"/>
+                                                    <rect key="frame" x="286" y="10" width="89" height="32"/>
                                                     <buttonCell key="cell" type="push" title="Remove" bezelStyle="rounded" alignment="center" borderStyle="border" inset="2" id="oQU-Vk-TEO">
                                                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                                         <font key="font" metaFont="system"/>
@@ -474,7 +474,7 @@
                                                     </connections>
                                                 </button>
                                                 <textField horizontalHuggingPriority="249" verticalHuggingPriority="750" setsMaxLayoutWidthAtFirstLayout="YES" translatesAutoresizingMaskIntoConstraints="NO" id="HY1-Mt-SGD">
-                                                    <rect key="frame" x="18" y="19" width="265" height="14"/>
+                                                    <rect key="frame" x="15" y="20" width="268" height="14"/>
                                                     <textFieldCell key="cell" sendsActionOnEndEditing="YES" title="Current architecture: %@" id="yB7-o0-eDt">
                                                         <font key="font" metaFont="smallSystem"/>
                                                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -483,15 +483,15 @@
                                                 </textField>
                                             </subviews>
                                             <constraints>
-                                                <constraint firstItem="MvI-uV-IhN" firstAttribute="top" secondItem="iOc-2Z-Ipp" secondAttribute="top" id="0VC-Fx-FvK"/>
-                                                <constraint firstAttribute="trailing" secondItem="MvI-uV-IhN" secondAttribute="trailing" constant="20" symbolic="YES" id="JzT-iB-qJe"/>
+                                                <constraint firstItem="MvI-uV-IhN" firstAttribute="top" secondItem="iOc-2Z-Ipp" secondAttribute="top" constant="3" id="0VC-Fx-FvK"/>
+                                                <constraint firstAttribute="trailing" secondItem="MvI-uV-IhN" secondAttribute="trailing" constant="17" id="Cd4-em-1dk"/>
+                                                <constraint firstItem="65V-iD-EUO" firstAttribute="leading" secondItem="HY1-Mt-SGD" secondAttribute="trailing" constant="11" id="MYE-Qu-fmO"/>
                                                 <constraint firstItem="HY1-Mt-SGD" firstAttribute="baseline" secondItem="65V-iD-EUO" secondAttribute="baseline" id="ad2-R5-1Mu"/>
-                                                <constraint firstAttribute="trailing" secondItem="65V-iD-EUO" secondAttribute="trailing" constant="20" id="caA-GF-CLp"/>
-                                                <constraint firstItem="HY1-Mt-SGD" firstAttribute="leading" secondItem="iOc-2Z-Ipp" secondAttribute="leading" constant="20" symbolic="YES" id="o6U-fb-MMK"/>
-                                                <constraint firstAttribute="bottom" secondItem="MvI-uV-IhN" secondAttribute="bottom" constant="57" id="uhc-Uu-fa3"/>
-                                                <constraint firstItem="MvI-uV-IhN" firstAttribute="leading" secondItem="iOc-2Z-Ipp" secondAttribute="leading" constant="20" symbolic="YES" id="vFb-ld-5Rc"/>
-                                                <constraint firstAttribute="bottom" secondItem="65V-iD-EUO" secondAttribute="bottom" constant="16" id="vmD-5S-RpN"/>
-                                                <constraint firstItem="65V-iD-EUO" firstAttribute="leading" secondItem="HY1-Mt-SGD" secondAttribute="trailing" constant="8" symbolic="YES" id="ydy-8T-wcg"/>
+                                                <constraint firstAttribute="trailing" secondItem="65V-iD-EUO" secondAttribute="trailing" constant="17" id="caA-GF-CLp"/>
+                                                <constraint firstItem="MvI-uV-IhN" firstAttribute="leading" secondItem="iOc-2Z-Ipp" secondAttribute="leading" constant="17" id="hln-Qp-e4J"/>
+                                                <constraint firstItem="HY1-Mt-SGD" firstAttribute="leading" secondItem="iOc-2Z-Ipp" secondAttribute="leading" constant="17" id="oCl-1y-ZMl"/>
+                                                <constraint firstAttribute="bottom" secondItem="MvI-uV-IhN" secondAttribute="bottom" constant="58" id="uhc-Uu-fa3"/>
+                                                <constraint firstAttribute="bottom" secondItem="65V-iD-EUO" secondAttribute="bottom" constant="17" id="vmD-5S-RpN"/>
                                             </constraints>
                                         </view>
                                     </tabViewItem>
@@ -585,16 +585,6 @@
                                     <binding destination="4nR-6U-bWS" name="value" keyPath="values.SUCheckAtStartup" id="YOp-4S-yiw"/>
                                 </connections>
                             </button>
-                            <button translatesAutoresizingMaskIntoConstraints="NO" id="EUm-lj-8tR">
-                                <rect key="frame" x="18" y="18" width="414" height="18"/>
-                                <buttonCell key="cell" type="check" title="Strip debug info when removing architectures" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="NXp-MA-naz">
-                                    <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
-                                    <font key="font" metaFont="system"/>
-                                </buttonCell>
-                                <connections>
-                                    <binding destination="4nR-6U-bWS" name="value" keyPath="values.Strip" id="Ckn-5O-KkQ"/>
-                                </connections>
-                            </button>
                             <box verticalHuggingPriority="249" title="Directories:" translatesAutoresizingMaskIntoConstraints="NO" id="55G-Fd-xJZ">
                                 <rect key="frame" x="17" y="78" width="416" height="262"/>
                                 <view key="contentView" id="phW-MN-TLV">
@@ -612,13 +602,13 @@
                                             </connections>
                                         </button>
                                         <scrollView autohidesScrollers="YES" horizontalLineScroll="19" horizontalPageScroll="10" verticalLineScroll="19" verticalPageScroll="10" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="tBG-2t-RdI">
-                                            <rect key="frame" x="17" y="47" width="378" height="188"/>
+                                            <rect key="frame" x="17" y="40" width="378" height="195"/>
                                             <clipView key="contentView" id="re4-3X-lnR">
-                                                <rect key="frame" x="1" y="0.0" width="376" height="187"/>
+                                                <rect key="frame" x="1" y="0.0" width="376" height="194"/>
                                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                 <subviews>
-                                                    <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" columnReordering="NO" columnSelection="YES" rowSizeStyle="automatic" headerView="xcr-EI-XkG" viewBased="YES" id="opZ-3w-oKJ">
-                                                        <rect key="frame" x="0.0" y="0.0" width="376" height="164"/>
+                                                    <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" alternatingRowBackgroundColors="YES" columnReordering="NO" columnSelection="YES" rowSizeStyle="automatic" headerView="xcr-EI-XkG" viewBased="YES" id="opZ-3w-oKJ">
+                                                        <rect key="frame" x="0.0" y="0.0" width="376" height="171"/>
                                                         <autoresizingMask key="autoresizingMask"/>
                                                         <size key="intercellSpacing" width="3" height="2"/>
                                                         <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
@@ -678,8 +668,8 @@
                                                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                                         <subviews>
                                                                             <button translatesAutoresizingMaskIntoConstraints="NO" id="Nba-o3-H1A">
-                                                                                <rect key="frame" x="34" y="0.0" width="22" height="18"/>
-                                                                                <buttonCell key="cell" type="check" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="xxv-81-44c">
+                                                                                <rect key="frame" x="35" y="0.0" width="18" height="18"/>
+                                                                                <buttonCell key="cell" type="check" bezelStyle="regularSquare" imagePosition="only" state="on" inset="2" id="xxv-81-44c">
                                                                                     <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                                                                     <font key="font" metaFont="system"/>
                                                                                 </buttonCell>
@@ -718,8 +708,8 @@
                                                                                 <rect key="frame" x="0.0" y="0.0" width="186" height="17"/>
                                                                                 <textFieldCell key="cell" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" usesSingleLineMode="YES" id="F34-1y-CM7">
                                                                                     <font key="font" metaFont="system"/>
-                                                                                    <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                                                    <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                                                    <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                                                                                    <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                                                                 </textFieldCell>
                                                                                 <connections>
                                                                                     <binding destination="a8l-8R-7ag" name="value" keyPath="objectValue.Path" id="fgf-lP-OGc"/>
@@ -768,12 +758,14 @@
                                             </connections>
                                         </button>
                                     </subviews>
+                                    <constraints>
+                                        <constraint firstItem="tBG-2t-RdI" firstAttribute="top" secondItem="phW-MN-TLV" secondAttribute="top" constant="10" id="7ux-Ce-nHb"/>
+                                    </constraints>
                                 </view>
                                 <constraints>
                                     <constraint firstAttribute="trailing" secondItem="N6P-44-zxI" secondAttribute="trailing" constant="16" id="63x-FZ-pNG"/>
                                     <constraint firstItem="txs-gW-YkQ" firstAttribute="centerY" secondItem="N6P-44-zxI" secondAttribute="centerY" id="A9G-4l-PMV"/>
-                                    <constraint firstItem="N6P-44-zxI" firstAttribute="top" secondItem="tBG-2t-RdI" secondAttribute="bottom" constant="14" id="OGl-Iv-8aS"/>
-                                    <constraint firstItem="tBG-2t-RdI" firstAttribute="top" secondItem="55G-Fd-xJZ" secondAttribute="top" constant="25" id="OlE-tA-thQ"/>
+                                    <constraint firstItem="N6P-44-zxI" firstAttribute="top" secondItem="tBG-2t-RdI" secondAttribute="bottom" constant="7" id="OGl-Iv-8aS"/>
                                     <constraint firstAttribute="trailing" secondItem="tBG-2t-RdI" secondAttribute="trailing" constant="16" id="ZyL-iN-m5f"/>
                                     <constraint firstItem="N6P-44-zxI" firstAttribute="leading" secondItem="txs-gW-YkQ" secondAttribute="trailing" constant="12" id="jza-hq-NLT"/>
                                     <constraint firstAttribute="bottom" secondItem="N6P-44-zxI" secondAttribute="bottom" constant="10" id="mnc-e4-ruQ"/>
@@ -781,7 +773,18 @@
                                 </constraints>
                                 <color key="borderColor" white="0.0" alpha="0.41999999999999998" colorSpace="calibratedWhite"/>
                                 <color key="fillColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
+                                <font key="titleFont" metaFont="message" size="11"/>
                             </box>
+                            <button translatesAutoresizingMaskIntoConstraints="NO" id="EUm-lj-8tR">
+                                <rect key="frame" x="18" y="18" width="414" height="18"/>
+                                <buttonCell key="cell" type="check" title="Strip debug info when removing architectures" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="NXp-MA-naz">
+                                    <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                    <font key="font" metaFont="system"/>
+                                </buttonCell>
+                                <connections>
+                                    <binding destination="4nR-6U-bWS" name="value" keyPath="values.Strip" id="Ckn-5O-KkQ"/>
+                                </connections>
+                            </button>
                         </subviews>
                         <constraints>
                             <constraint firstItem="EUm-lj-8tR" firstAttribute="trailing" secondItem="bfw-zw-wXa" secondAttribute="trailing" id="0xG-3v-fAX"/>
@@ -828,27 +831,19 @@
             <objects>
                 <viewController storyboardIdentifier="ProgressViewController" id="M12-nr-lB2" customClass="ProgressViewController" customModule="Monolingual" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" id="WE0-wO-Apd">
-                        <rect key="frame" x="0.0" y="0.0" width="420" height="105"/>
+                        <rect key="frame" x="0.0" y="0.0" width="420" height="107"/>
                         <autoresizingMask key="autoresizingMask"/>
                         <subviews>
                             <progressIndicator wantsLayer="YES" verticalHuggingPriority="750" minValue="10" maxValue="100" doubleValue="10" bezeled="NO" indeterminate="YES" style="bar" translatesAutoresizingMaskIntoConstraints="NO" id="W8a-kQ-cLh">
-                                <rect key="frame" x="20" y="19" width="304" height="20"/>
+                                <rect key="frame" x="20" y="19" width="302" height="22"/>
                                 <constraints>
-                                    <constraint firstAttribute="height" constant="18" id="5o4-wU-7gj"/>
+                                    <constraint firstAttribute="height" constant="20" id="5o4-wU-7gj"/>
                                 </constraints>
                             </progressIndicator>
-                            <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" setsMaxLayoutWidthAtFirstLayout="YES" translatesAutoresizingMaskIntoConstraints="NO" id="f9B-Zg-VSa">
-                                <rect key="frame" x="18" y="47" width="384" height="13"/>
-                                <textFieldCell key="cell" lineBreakMode="truncatingMiddle" sendsActionOnEndEditing="YES" alignment="left" title="Filename" usesSingleLineMode="YES" id="cDA-Ww-acB">
-                                    <font key="font" metaFont="label"/>
-                                    <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                    <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                </textFieldCell>
-                            </textField>
                             <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" setsMaxLayoutWidthAtFirstLayout="YES" translatesAutoresizingMaskIntoConstraints="NO" id="m2T-xo-c0U">
-                                <rect key="frame" x="18" y="68" width="384" height="17"/>
+                                <rect key="frame" x="18" y="70" width="384" height="17"/>
                                 <textFieldCell key="cell" lineBreakMode="truncatingMiddle" sendsActionOnEndEditing="YES" alignment="left" title="Application" usesSingleLineMode="YES" id="2Hg-My-pnU">
-                                    <font key="font" metaFont="system"/>
+                                    <font key="font" metaFont="titleBar"/>
                                     <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                                     <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                 </textFieldCell>
@@ -863,6 +858,14 @@
                                     <action selector="cancelButton:" target="M12-nr-lB2" id="m5K-JT-0DV"/>
                                 </connections>
                             </button>
+                            <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" setsMaxLayoutWidthAtFirstLayout="YES" translatesAutoresizingMaskIntoConstraints="NO" id="f9B-Zg-VSa">
+                                <rect key="frame" x="18" y="49" width="384" height="13"/>
+                                <textFieldCell key="cell" lineBreakMode="truncatingMiddle" sendsActionOnEndEditing="YES" alignment="left" title="Filename" usesSingleLineMode="YES" id="cDA-Ww-acB">
+                                    <font key="font" metaFont="label"/>
+                                    <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                    <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                </textFieldCell>
+                            </textField>
                         </subviews>
                         <constraints>
                             <constraint firstItem="f9B-Zg-VSa" firstAttribute="leading" secondItem="WE0-wO-Apd" secondAttribute="leading" constant="20" symbolic="YES" id="3UA-GO-Kt0"/>
@@ -875,7 +878,7 @@
                             <constraint firstItem="f9B-Zg-VSa" firstAttribute="top" secondItem="m2T-xo-c0U" secondAttribute="bottom" constant="8" id="c2e-eB-6Ms"/>
                             <constraint firstAttribute="bottom" secondItem="W8a-kQ-cLh" secondAttribute="bottom" constant="20" symbolic="YES" id="ckV-IJ-qFv"/>
                             <constraint firstAttribute="trailing" secondItem="EFT-7p-uKL" secondAttribute="trailing" constant="20" symbolic="YES" id="fVA-7y-6wn"/>
-                            <constraint firstItem="EFT-7p-uKL" firstAttribute="leading" secondItem="W8a-kQ-cLh" secondAttribute="trailing" constant="6" id="kI3-Yc-np6"/>
+                            <constraint firstItem="EFT-7p-uKL" firstAttribute="leading" secondItem="W8a-kQ-cLh" secondAttribute="trailing" constant="8" id="kI3-Yc-np6"/>
                             <constraint firstAttribute="trailing" secondItem="f9B-Zg-VSa" secondAttribute="trailing" constant="20" symbolic="YES" id="qhe-5r-c98"/>
                         </constraints>
                     </view>

--- a/Resources/de.lproj/Main.strings
+++ b/Resources/de.lproj/Main.strings
@@ -140,5 +140,8 @@
 /* Class = "NSTextFieldCell"; title = "Wählen Sie die Elemente aus, die Sie entfernen möchten:"; ObjectID = "z6z-xJ-Pjk"; */
 "z6z-xJ-Pjk.title" = "Wählen Sie die Elemente aus, die Sie entfernen möchten:";
 
+/* Class = "NSTextFieldCell"; title = "Wählen Sie die Elemente aus, die Sie entfernen möchten:"; ObjectID = "4Es-9R-gAn"; */
+"4Es-9R-gAn.title" = "Wählen Sie die Elemente aus, die Sie entfernen möchten:";
+
 /* Class = "NSWindow"; title = "Einstellungen"; ObjectID = "zCt-fj-HIv"; */
 "zCt-fj-HIv.title" = "Einstellungen";

--- a/Resources/de.lproj/Main.strings
+++ b/Resources/de.lproj/Main.strings
@@ -1,67 +1,68 @@
-/* Class = "NSTableColumn"; headerCell.title = "Remove"; ObjectID = "1XJ-Gd-jYy"; */
+
+/* Class = "NSTableColumn"; headerCell.title = "Entfernen"; ObjectID = "1XJ-Gd-jYy"; */
 "1XJ-Gd-jYy.headerCell.title" = "Entfernen";
 
 /* Class = "NSMenuItem"; title = "Monolingual"; ObjectID = "1Xt-HY-uBw"; */
 "1Xt-HY-uBw.title" = "Monolingual";
 
-/* Class = "NSTextFieldCell"; title = "Application"; ObjectID = "2Hg-My-pnU"; */
-"2Hg-My-pnU.title" = "Application";
+/* Class = "NSTextFieldCell"; title = "Anwendung"; ObjectID = "2Hg-My-pnU"; */
+"2Hg-My-pnU.title" = "Anwendung";
 
-/* Class = "NSMenuItem"; title = "Quit Monolingual"; ObjectID = "4sb-4s-VLi"; */
+/* Class = "NSMenuItem"; title = "Monolingual beenden"; ObjectID = "4sb-4s-VLi"; */
 "4sb-4s-VLi.title" = "Monolingual beenden";
 
-/* Class = "NSMenuItem"; title = "About Monolingual"; ObjectID = "5kV-Vb-QxS"; */
+/* Class = "NSBox"; title = "Verzeichnisse"; ObjectID = "55G-Fd-xJZ"; */
+"55G-Fd-xJZ.title" = "Verzeichnisse";
+
+/* Class = "NSMenuItem"; title = "Über Monolingual"; ObjectID = "5kV-Vb-QxS"; */
 "5kV-Vb-QxS.title" = "Über Monolingual";
 
-/* Class = "NSTableColumn"; headerCell.title = "Architecture"; ObjectID = "5qX-Sa-tJD"; */
+/* Class = "NSTableColumn"; headerCell.title = "Architektur"; ObjectID = "5qX-Sa-tJD"; */
 "5qX-Sa-tJD.headerCell.title" = "Architektur";
 
-/* Class = "NSButtonCell"; title = "Remove"; ObjectID = "7bE-Hh-5SU"; */
-"7bE-Hh-5SU.title" = "Entfernen";
+/* Class = "NSButtonCell"; title = "Entfernen …"; ObjectID = "7bE-Hh-5SU"; */
+"7bE-Hh-5SU.title" = "Entfernen …";
 
-/* Class = "NSBox"; title = "Directories:"; ObjectID = "55G-Fd-xJZ"; */
-"55G-Fd-xJZ.title" = "Verzeichnisse:";
+/* Class = "NSMenu"; title = "Hauptmenü"; ObjectID = "AYu-sK-qS6"; */
+"AYu-sK-qS6.title" = "Hauptmenü";
 
-/* Class = "NSMenu"; title = "Main Menu"; ObjectID = "AYu-sK-qS6"; */
-"AYu-sK-qS6.title" = "Main Menu";
+/* Class = "NSMenuItem"; title = "Einstellungen …"; ObjectID = "BOF-NM-1cW"; */
+"BOF-NM-1cW.title" = "Einstellungen …";
 
-/* Class = "NSMenuItem"; title = "Preferences…"; ObjectID = "BOF-NM-1cW"; */
-"BOF-NM-1cW.title" = "Einstellungen…";
-
-/* Class = "NSTabViewItem"; label = "Architectures"; ObjectID = "CxN-75-fAV"; */
+/* Class = "NSTabViewItem"; label = "Architekturen"; ObjectID = "CxN-75-fAV"; */
 "CxN-75-fAV.label" = "Architekturen";
 
-/* Class = "NSMenu"; title = "Help"; ObjectID = "F2S-fz-NVQ"; */
+/* Class = "NSMenu"; title = "Hilfe"; ObjectID = "F2S-fz-NVQ"; */
 "F2S-fz-NVQ.title" = "Hilfe";
 
-/* Class = "NSButtonCell"; title = "Move language files to trash"; ObjectID = "GpT-ew-TUw"; */
+/* Class = "NSButtonCell"; title = "Sprachdateien in den Papierkorb verschieben"; ObjectID = "GpT-ew-TUw"; */
 "GpT-ew-TUw.title" = "Sprachdateien in den Papierkorb verschieben";
 
 /* Class = "NSWindow"; title = "Monolingual"; ObjectID = "IQv-IB-iLA"; */
 "IQv-IB-iLA.title" = "Monolingual";
 
-/* Class = "NSMenuItem"; title = "Show All"; ObjectID = "Kd2-mp-pUS"; */
+/* Class = "NSMenuItem"; title = "Alle einblenden"; ObjectID = "Kd2-mp-pUS"; */
 "Kd2-mp-pUS.title" = "Alle einblenden";
 
-/* Class = "NSMenuItem"; title = "Bring All to Front"; ObjectID = "LE2-aR-0XJ"; */
+/* Class = "NSMenuItem"; title = "Alle nach vorne bringen"; ObjectID = "LE2-aR-0XJ"; */
 "LE2-aR-0XJ.title" = "Alle nach vorne bringen";
 
-/* Class = "NSMenuItem"; title = "Services"; ObjectID = "NMo-om-nkz"; */
+/* Class = "NSMenuItem"; title = "Dienste"; ObjectID = "NMo-om-nkz"; */
 "NMo-om-nkz.title" = "Dienste";
 
-/* Class = "NSButtonCell"; title = "Strip debug info when removing architectures"; ObjectID = "NXp-MA-naz"; */
+/* Class = "NSButtonCell"; title = "Debug-Informationen entfernen"; ObjectID = "NXp-MA-naz"; */
 "NXp-MA-naz.title" = "Debug-Informationen entfernen";
 
-/* Class = "NSTableColumn"; headerCell.title = "Architectures"; ObjectID = "No6-FX-Y9X"; */
+/* Class = "NSTableColumn"; headerCell.title = "Architekturen"; ObjectID = "No6-FX-Y9X"; */
 "No6-FX-Y9X.headerCell.title" = "Architekturen";
 
-/* Class = "NSTableColumn"; headerCell.title = "Path"; ObjectID = "OFP-Qj-bkb"; */
+/* Class = "NSTableColumn"; headerCell.title = "Pfad"; ObjectID = "OFP-Qj-bkb"; */
 "OFP-Qj-bkb.headerCell.title" = "Pfad";
 
-/* Class = "NSMenuItem"; title = "Minimize"; ObjectID = "OY7-WF-poV"; */
+/* Class = "NSMenuItem"; title = "Im Dock ablegen"; ObjectID = "OY7-WF-poV"; */
 "OY7-WF-poV.title" = "Im Dock ablegen";
 
-/* Class = "NSMenuItem"; title = "Hide Monolingual"; ObjectID = "Olw-nP-bQN"; */
+/* Class = "NSMenuItem"; title = "Monolingual ausblenden"; ObjectID = "Olw-nP-bQN"; */
 "Olw-nP-bQN.title" = "Monolingual ausblenden";
 
 /* Class = "NSMenuItem"; title = "Zoom"; ObjectID = "R4o-n2-Eq4"; */
@@ -70,52 +71,52 @@
 /* Class = "NSMenuItem"; title = "Monolingual Website"; ObjectID = "T0F-eG-SQM"; */
 "T0F-eG-SQM.title" = "Monolingual Website";
 
-/* Class = "NSMenu"; title = "Window"; ObjectID = "Td7-aD-5lo"; */
+/* Class = "NSMenu"; title = "Fenster"; ObjectID = "Td7-aD-5lo"; */
 "Td7-aD-5lo.title" = "Fenster";
 
-/* Class = "NSButtonCell"; title = "Check for updates at startup"; ObjectID = "Ug3-e7-H88"; */
-"Ug3-e7-H88.title" = "Beim Start nach Updates suchen";
+/* Class = "NSButtonCell"; title = "Beim Start nach Aktualisierungen suchen"; ObjectID = "Ug3-e7-H88"; */
+"Ug3-e7-H88.title" = "Beim Start nach Aktualisierungen suchen";
 
-/* Class = "NSMenuItem"; title = "Hide Others"; ObjectID = "Vdr-fp-XzO"; */
+/* Class = "NSMenuItem"; title = "Andere ausblenden"; ObjectID = "Vdr-fp-XzO"; */
 "Vdr-fp-XzO.title" = "Andere ausblenden";
 
-/* Class = "NSTableColumn"; headerCell.title = "Language"; ObjectID = "XXG-zZ-uSC"; */
+/* Class = "NSTableColumn"; headerCell.title = "Sprache"; ObjectID = "XXG-zZ-uSC"; */
 "XXG-zZ-uSC.headerCell.title" = "Sprache";
 
-/* Class = "NSButtonCell"; title = "Add"; ObjectID = "aFz-HG-feS"; */
+/* Class = "NSButtonCell"; title = "Hinzufügen"; ObjectID = "aFz-HG-feS"; */
 "aFz-HG-feS.title" = "Hinzufügen";
 
-/* Class = "NSMenuItem"; title = "Window"; ObjectID = "aUF-d1-5bR"; */
+/* Class = "NSMenuItem"; title = "Fenster"; ObjectID = "aUF-d1-5bR"; */
 "aUF-d1-5bR.title" = "Fenster";
 
-/* Class = "NSTabViewItem"; label = "Languages"; ObjectID = "bcK-xR-VFN"; */
+/* Class = "NSTabViewItem"; label = "Sprachen"; ObjectID = "bcK-xR-VFN"; */
 "bcK-xR-VFN.label" = "Sprachen";
 
-/* Class = "NSMenuItem"; title = "README.rtfd"; ObjectID = "bhF-6u-WYT"; */
+/* Class = "NSMenuItem"; title = "Lies-mich.rtfd"; ObjectID = "bhF-6u-WYT"; */
 "bhF-6u-WYT.title" = "Lies-mich.rtfd";
 
-/* Class = "NSTextFieldCell"; title = "Filename"; ObjectID = "cDA-Ww-acB"; */
-"cDA-Ww-acB.title" = "Filename";
+/* Class = "NSTextFieldCell"; title = "Dateiname"; ObjectID = "cDA-Ww-acB"; */
+"cDA-Ww-acB.title" = "Dateiname";
 
-/* Class = "NSMenu"; title = "Services"; ObjectID = "hz9-B4-Xy5"; */
+/* Class = "NSMenu"; title = "Dienste"; ObjectID = "hz9-B4-Xy5"; */
 "hz9-B4-Xy5.title" = "Dienste";
 
-/* Class = "NSButtonCell"; title = "Remove"; ObjectID = "iw9-pP-alf"; */
+/* Class = "NSButtonCell"; title = "Entfernen"; ObjectID = "iw9-pP-alf"; */
 "iw9-pP-alf.title" = "Entfernen";
 
-/* Class = "NSButtonCell"; title = "Remove"; ObjectID = "oQU-Vk-TEO"; */
-"oQU-Vk-TEO.title" = "Entfernen";
+/* Class = "NSButtonCell"; title = "Entfernen …"; ObjectID = "oQU-Vk-TEO"; */
+"oQU-Vk-TEO.title" = "Entfernen …";
 
-/* Class = "NSMenuItem"; title = "Check for Update"; ObjectID = "ovG-l7-8cL"; */
-"ovG-l7-8cL.title" = "Nach Update suchen";
+/* Class = "NSMenuItem"; title = "Nach Aktualisierungen suchen"; ObjectID = "ovG-l7-8cL"; */
+"ovG-l7-8cL.title" = "Nach Aktualisierungen suchen";
 
-/* Class = "NSMenuItem"; title = "Donate"; ObjectID = "p8d-r6-xqF"; */
+/* Class = "NSMenuItem"; title = "Spenden"; ObjectID = "p8d-r6-xqF"; */
 "p8d-r6-xqF.title" = "Spenden";
 
-/* Class = "NSTableColumn"; headerCell.title = "Remove"; ObjectID = "pBV-1w-hWv"; */
+/* Class = "NSTableColumn"; headerCell.title = "Entfernen"; ObjectID = "pBV-1w-hWv"; */
 "pBV-1w-hWv.headerCell.title" = "Entfernen";
 
-/* Class = "NSMenuItem"; title = "Close"; ObjectID = "rCa-FF-cP0"; */
+/* Class = "NSMenuItem"; title = "Schließen"; ObjectID = "rCa-FF-cP0"; */
 "rCa-FF-cP0.title" = "Schließen";
 
 /* Class = "NSMenuItem"; title = "LICENSE.txt"; ObjectID = "uKg-49-FCQ"; */
@@ -124,21 +125,20 @@
 /* Class = "NSMenu"; title = "Monolingual"; ObjectID = "uQy-DD-JDr"; */
 "uQy-DD-JDr.title" = "Monolingual";
 
-/* Class = "NSButtonCell"; title = "Cancel"; ObjectID = "vMP-PK-qKF"; */
+/* Class = "NSButtonCell"; title = "Abbrechen"; ObjectID = "vMP-PK-qKF"; */
 "vMP-PK-qKF.title" = "Abbrechen";
 
-/* Class = "NSTableColumn"; headerCell.title = "Languages"; ObjectID = "weW-SY-p4l"; */
+/* Class = "NSTableColumn"; headerCell.title = "Sprachen"; ObjectID = "weW-SY-p4l"; */
 "weW-SY-p4l.headerCell.title" = "Sprachen";
 
-/* Class = "NSMenuItem"; title = "Help"; ObjectID = "wpr-3q-Mcd"; */
+/* Class = "NSMenuItem"; title = "Hilfe"; ObjectID = "wpr-3q-Mcd"; */
 "wpr-3q-Mcd.title" = "Hilfe";
 
-/* Class = "NSTextFieldCell"; title = "Current architecture: %@"; ObjectID = "yB7-o0-eDt"; */
-"yB7-o0-eDt.title" = "Current architecture: %@";
+/* Class = "NSTextFieldCell"; title = "Aktuelle Architektur: %@"; ObjectID = "yB7-o0-eDt"; */
+"yB7-o0-eDt.title" = "Aktuelle Architektur: %@";
 
-/* Class = "NSTextFieldCell"; title = "Select the items you wish to remove:"; ObjectID = "z6z-xJ-Pjk"; */
+/* Class = "NSTextFieldCell"; title = "Wählen Sie die Elemente aus, die Sie entfernen möchten:"; ObjectID = "z6z-xJ-Pjk"; */
 "z6z-xJ-Pjk.title" = "Wählen Sie die Elemente aus, die Sie entfernen möchten:";
 
-/* Class = "NSWindow"; title = "Preferences"; ObjectID = "zCt-fj-HIv"; */
+/* Class = "NSWindow"; title = "Einstellungen"; ObjectID = "zCt-fj-HIv"; */
 "zCt-fj-HIv.title" = "Einstellungen";
-

--- a/Resources/el.lproj/Main.strings
+++ b/Resources/el.lproj/Main.strings
@@ -17,10 +17,10 @@
 "5qX-Sa-tJD.headerCell.title" = "Architecture";
 
 /* Class = "NSButtonCell"; title = "Remove"; ObjectID = "7bE-Hh-5SU"; */
-"7bE-Hh-5SU.title" = "Αφαίρεση";
+"7bE-Hh-5SU.title" = "Αφαίρεση…";
 
 /* Class = "NSBox"; title = "Directories:"; ObjectID = "55G-Fd-xJZ"; */
-"55G-Fd-xJZ.title" = "Directories:";
+"55G-Fd-xJZ.title" = "Directories";
 
 /* Class = "NSMenu"; title = "Main Menu"; ObjectID = "AYu-sK-qS6"; */
 "AYu-sK-qS6.title" = "Main Menu";
@@ -104,7 +104,7 @@
 "iw9-pP-alf.title" = "Αφαίρεση";
 
 /* Class = "NSButtonCell"; title = "Remove"; ObjectID = "oQU-Vk-TEO"; */
-"oQU-Vk-TEO.title" = "Αφαίρεση";
+"oQU-Vk-TEO.title" = "Αφαίρεση…";
 
 /* Class = "NSMenuItem"; title = "Check for Update"; ObjectID = "ovG-l7-8cL"; */
 "ovG-l7-8cL.title" = "Check for Update";

--- a/Resources/el.lproj/Main.strings
+++ b/Resources/el.lproj/Main.strings
@@ -139,6 +139,9 @@
 /* Class = "NSTextFieldCell"; title = "Select the items you wish to remove:"; ObjectID = "z6z-xJ-Pjk"; */
 "z6z-xJ-Pjk.title" = "Επιλογή στοιχείων για αφαίρεση:";
 
+/* Class = "NSTextFieldCell"; title = "Select the items you wish to remove:"; ObjectID = "4Es-9R-gAn"; */
+"4Es-9R-gAn.title" = "Επιλογή στοιχείων για αφαίρεση:";
+
 /* Class = "NSWindow"; title = "Preferences"; ObjectID = "zCt-fj-HIv"; */
 "zCt-fj-HIv.title" = "Προτιμήσεις";
 

--- a/Resources/en.lproj/Main.strings
+++ b/Resources/en.lproj/Main.strings
@@ -139,6 +139,9 @@
 /* Class = "NSTextFieldCell"; title = "Select the items you wish to remove:"; ObjectID = "z6z-xJ-Pjk"; */
 "z6z-xJ-Pjk.title" = "Select the items you wish to remove:";
 
+/* Class = "NSTextFieldCell"; title = "Select the items you wish to remove:"; ObjectID = "4Es-9R-gAn"; */
+"4Es-9R-gAn.title" = "Select the items you wish to remove:";
+
 /* Class = "NSWindow"; title = "Preferences"; ObjectID = "zCt-fj-HIv"; */
 "zCt-fj-HIv.title" = "Preferences";
 

--- a/Resources/en.lproj/Main.strings
+++ b/Resources/en.lproj/Main.strings
@@ -17,10 +17,10 @@
 "5qX-Sa-tJD.headerCell.title" = "Architecture";
 
 /* Class = "NSButtonCell"; title = "Remove"; ObjectID = "7bE-Hh-5SU"; */
-"7bE-Hh-5SU.title" = "Remove";
+"7bE-Hh-5SU.title" = "Remove…";
 
 /* Class = "NSBox"; title = "Directories:"; ObjectID = "55G-Fd-xJZ"; */
-"55G-Fd-xJZ.title" = "Directories:";
+"55G-Fd-xJZ.title" = "Directories";
 
 /* Class = "NSMenu"; title = "Main Menu"; ObjectID = "AYu-sK-qS6"; */
 "AYu-sK-qS6.title" = "Main Menu";
@@ -35,7 +35,7 @@
 "F2S-fz-NVQ.title" = "Help";
 
 /* Class = "NSButtonCell"; title = "Move language files to trash"; ObjectID = "GpT-ew-TUw"; */
-"GpT-ew-TUw.title" = "Move language files to trash";
+"GpT-ew-TUw.title" = "Move language files to Trash";
 
 /* Class = "NSWindow"; title = "Monolingual"; ObjectID = "IQv-IB-iLA"; */
 "IQv-IB-iLA.title" = "Monolingual";
@@ -104,7 +104,7 @@
 "iw9-pP-alf.title" = "Remove";
 
 /* Class = "NSButtonCell"; title = "Remove"; ObjectID = "oQU-Vk-TEO"; */
-"oQU-Vk-TEO.title" = "Remove";
+"oQU-Vk-TEO.title" = "Remove…";
 
 /* Class = "NSMenuItem"; title = "Check for Update"; ObjectID = "ovG-l7-8cL"; */
 "ovG-l7-8cL.title" = "Check for Update";

--- a/Resources/es.lproj/Main.strings
+++ b/Resources/es.lproj/Main.strings
@@ -139,6 +139,9 @@
 /* Class = "NSTextFieldCell"; title = "Select the items you wish to remove:"; ObjectID = "z6z-xJ-Pjk"; */
 "z6z-xJ-Pjk.title" = "Selecciona los idiomas que quieres eliminar:";
 
+/* Class = "NSTextFieldCell"; title = "Select the items you wish to remove:"; ObjectID = "4Es-9R-gAn"; */
+"4Es-9R-gAn.title" = "Selecciona los idiomas que quieres eliminar:";
+
 /* Class = "NSWindow"; title = "Preferences"; ObjectID = "zCt-fj-HIv"; */
 "zCt-fj-HIv.title" = "Preferencias";
 

--- a/Resources/es.lproj/Main.strings
+++ b/Resources/es.lproj/Main.strings
@@ -17,10 +17,10 @@
 "5qX-Sa-tJD.headerCell.title" = "Architecture";
 
 /* Class = "NSButtonCell"; title = "Remove"; ObjectID = "7bE-Hh-5SU"; */
-"7bE-Hh-5SU.title" = "Eliminar";
+"7bE-Hh-5SU.title" = "Eliminar…";
 
 /* Class = "NSBox"; title = "Directories:"; ObjectID = "55G-Fd-xJZ"; */
-"55G-Fd-xJZ.title" = "Directorios:";
+"55G-Fd-xJZ.title" = "Directorios";
 
 /* Class = "NSMenu"; title = "Main Menu"; ObjectID = "AYu-sK-qS6"; */
 "AYu-sK-qS6.title" = "Menú principal";
@@ -104,7 +104,7 @@
 "iw9-pP-alf.title" = "Eliminar";
 
 /* Class = "NSButtonCell"; title = "Remove"; ObjectID = "oQU-Vk-TEO"; */
-"oQU-Vk-TEO.title" = "Eliminar";
+"oQU-Vk-TEO.title" = "Eliminar…";
 
 /* Class = "NSMenuItem"; title = "Check for Update"; ObjectID = "ovG-l7-8cL"; */
 "ovG-l7-8cL.title" = "Comprobar actualizaciones";

--- a/Resources/fr.lproj/Main.strings
+++ b/Resources/fr.lproj/Main.strings
@@ -139,6 +139,9 @@
 /* Class = "NSTextFieldCell"; title = "Select the items you wish to remove:"; ObjectID = "z6z-xJ-Pjk"; */
 "z6z-xJ-Pjk.title" = "Sélectionnez les langues à supprimer:";
 
+/* Class = "NSTextFieldCell"; title = "Select the items you wish to remove:"; ObjectID = "4Es-9R-gAn"; */
+"4Es-9R-gAn.title" = "Sélectionnez les langues à supprimer:";
+
 /* Class = "NSWindow"; title = "Preferences"; ObjectID = "zCt-fj-HIv"; */
 "zCt-fj-HIv.title" = "Preferences";
 

--- a/Resources/fr.lproj/Main.strings
+++ b/Resources/fr.lproj/Main.strings
@@ -17,10 +17,10 @@
 "5qX-Sa-tJD.headerCell.title" = "Architecture";
 
 /* Class = "NSButtonCell"; title = "Remove"; ObjectID = "7bE-Hh-5SU"; */
-"7bE-Hh-5SU.title" = "Supprimer";
+"7bE-Hh-5SU.title" = "Supprimer…";
 
 /* Class = "NSBox"; title = "Directories:"; ObjectID = "55G-Fd-xJZ"; */
-"55G-Fd-xJZ.title" = "Directories:";
+"55G-Fd-xJZ.title" = "Directories";
 
 /* Class = "NSMenu"; title = "Main Menu"; ObjectID = "AYu-sK-qS6"; */
 "AYu-sK-qS6.title" = "Main Menu";
@@ -104,7 +104,7 @@
 "iw9-pP-alf.title" = "Supprimer";
 
 /* Class = "NSButtonCell"; title = "Remove"; ObjectID = "oQU-Vk-TEO"; */
-"oQU-Vk-TEO.title" = "Supprimer";
+"oQU-Vk-TEO.title" = "Supprimer…";
 
 /* Class = "NSMenuItem"; title = "Check for Update"; ObjectID = "ovG-l7-8cL"; */
 "ovG-l7-8cL.title" = "Check for Update";

--- a/Resources/hr.lproj/Main.strings
+++ b/Resources/hr.lproj/Main.strings
@@ -139,6 +139,9 @@
 /* Class = "NSTextFieldCell"; title = "Select the items you wish to remove:"; ObjectID = "z6z-xJ-Pjk"; */
 "z6z-xJ-Pjk.title" = "Odaberite stavke koje želite ukloniti:";
 
+/* Class = "NSTextFieldCell"; title = "Select the items you wish to remove:"; ObjectID = "4Es-9R-gAn"; */
+"4Es-9R-gAn.title" = "Odaberite stavke koje želite ukloniti:";
+
 /* Class = "NSWindow"; title = "Preferences"; ObjectID = "zCt-fj-HIv"; */
 "zCt-fj-HIv.title" = "Postavke";
 

--- a/Resources/hr.lproj/Main.strings
+++ b/Resources/hr.lproj/Main.strings
@@ -17,10 +17,10 @@
 "5qX-Sa-tJD.headerCell.title" = "Arhitektura";
 
 /* Class = "NSButtonCell"; title = "Remove"; ObjectID = "7bE-Hh-5SU"; */
-"7bE-Hh-5SU.title" = "Ukloni";
+"7bE-Hh-5SU.title" = "Ukloni…";
 
 /* Class = "NSBox"; title = "Directories:"; ObjectID = "55G-Fd-xJZ"; */
-"55G-Fd-xJZ.title" = "Mape:";
+"55G-Fd-xJZ.title" = "Mape";
 
 /* Class = "NSMenu"; title = "Main Menu"; ObjectID = "AYu-sK-qS6"; */
 "AYu-sK-qS6.title" = "Glavni izbornik";
@@ -104,7 +104,7 @@
 "iw9-pP-alf.title" = "Ukloni";
 
 /* Class = "NSButtonCell"; title = "Remove"; ObjectID = "oQU-Vk-TEO"; */
-"oQU-Vk-TEO.title" = "Ukloni";
+"oQU-Vk-TEO.title" = "Ukloni…";
 
 /* Class = "NSMenuItem"; title = "Check for Update"; ObjectID = "ovG-l7-8cL"; */
 "ovG-l7-8cL.title" = "Provjeri ažuriranja";

--- a/Resources/it.lproj/Main.strings
+++ b/Resources/it.lproj/Main.strings
@@ -17,10 +17,10 @@
 "5qX-Sa-tJD.headerCell.title" = "Architecture";
 
 /* Class = "NSButtonCell"; title = "Remove"; ObjectID = "7bE-Hh-5SU"; */
-"7bE-Hh-5SU.title" = "Elimina";
+"7bE-Hh-5SU.title" = "Elimina…";
 
 /* Class = "NSBox"; title = "Directories:"; ObjectID = "55G-Fd-xJZ"; */
-"55G-Fd-xJZ.title" = "Directories:";
+"55G-Fd-xJZ.title" = "Directories";
 
 /* Class = "NSMenu"; title = "Main Menu"; ObjectID = "AYu-sK-qS6"; */
 "AYu-sK-qS6.title" = "Main Menu";
@@ -104,7 +104,7 @@
 "iw9-pP-alf.title" = "Elimina";
 
 /* Class = "NSButtonCell"; title = "Remove"; ObjectID = "oQU-Vk-TEO"; */
-"oQU-Vk-TEO.title" = "Elimina";
+"oQU-Vk-TEO.title" = "Elimina…";
 
 /* Class = "NSMenuItem"; title = "Check for Update"; ObjectID = "ovG-l7-8cL"; */
 "ovG-l7-8cL.title" = "Check for Update";

--- a/Resources/it.lproj/Main.strings
+++ b/Resources/it.lproj/Main.strings
@@ -139,6 +139,9 @@
 /* Class = "NSTextFieldCell"; title = "Select the items you wish to remove:"; ObjectID = "z6z-xJ-Pjk"; */
 "z6z-xJ-Pjk.title" = "Seleziona gli elementi che desideri eliminare:";
 
+/* Class = "NSTextFieldCell"; title = "Select the items you wish to remove:"; ObjectID = "4Es-9R-gAn"; */
+"4Es-9R-gAn.title" = "Seleziona gli elementi che desideri eliminare:";
+
 /* Class = "NSWindow"; title = "Preferences"; ObjectID = "zCt-fj-HIv"; */
 "zCt-fj-HIv.title" = "Preferenze";
 

--- a/Resources/ja.lproj/Main.strings
+++ b/Resources/ja.lproj/Main.strings
@@ -139,6 +139,9 @@
 /* Class = "NSTextFieldCell"; title = "Select the items you wish to remove:"; ObjectID = "z6z-xJ-Pjk"; */
 "z6z-xJ-Pjk.title" = "削除する言語を選択してください：";
 
+/* Class = "NSTextFieldCell"; title = "Select the items you wish to remove:"; ObjectID = "4Es-9R-gAn"; */
+"4Es-9R-gAn.title" = "削除する言語を選択してください：";
+
 /* Class = "NSWindow"; title = "Preferences"; ObjectID = "zCt-fj-HIv"; */
 "zCt-fj-HIv.title" = "Preferences";
 

--- a/Resources/ja.lproj/Main.strings
+++ b/Resources/ja.lproj/Main.strings
@@ -17,10 +17,10 @@
 "5qX-Sa-tJD.headerCell.title" = "Architecture";
 
 /* Class = "NSButtonCell"; title = "Remove"; ObjectID = "7bE-Hh-5SU"; */
-"7bE-Hh-5SU.title" = "削除";
+"7bE-Hh-5SU.title" = "削除…";
 
 /* Class = "NSBox"; title = "Directories:"; ObjectID = "55G-Fd-xJZ"; */
-"55G-Fd-xJZ.title" = "Directories:";
+"55G-Fd-xJZ.title" = "Directories";
 
 /* Class = "NSMenu"; title = "Main Menu"; ObjectID = "AYu-sK-qS6"; */
 "AYu-sK-qS6.title" = "Main Menu";
@@ -104,7 +104,7 @@
 "iw9-pP-alf.title" = "削除";
 
 /* Class = "NSButtonCell"; title = "Remove"; ObjectID = "oQU-Vk-TEO"; */
-"oQU-Vk-TEO.title" = "削除";
+"oQU-Vk-TEO.title" = "削除…";
 
 /* Class = "NSMenuItem"; title = "Check for Update"; ObjectID = "ovG-l7-8cL"; */
 "ovG-l7-8cL.title" = "Check for Update";

--- a/Resources/ko.lproj/Main.strings
+++ b/Resources/ko.lproj/Main.strings
@@ -12,7 +12,7 @@
 "4sb-4s-VLi.title" = "Monolingual 종료";
 
 /* Class = "NSBox"; title = "Directories:"; ObjectID = "55G-Fd-xJZ"; */
-"55G-Fd-xJZ.title" = "디렉터리:";
+"55G-Fd-xJZ.title" = "디렉터리";
 
 /* Class = "NSMenuItem"; title = "About Monolingual"; ObjectID = "5kV-Vb-QxS"; */
 "5kV-Vb-QxS.title" = "Monolingual에 대하여";
@@ -21,7 +21,7 @@
 "5qX-Sa-tJD.headerCell.title" = "아키텍처";
 
 /* Class = "NSButtonCell"; title = "Remove"; ObjectID = "7bE-Hh-5SU"; */
-"7bE-Hh-5SU.title" = "삭제";
+"7bE-Hh-5SU.title" = "삭제…";
 
 /* Class = "NSMenu"; title = "Main Menu"; ObjectID = "AYu-sK-qS6"; */
 "AYu-sK-qS6.title" = "주 메뉴";
@@ -114,7 +114,7 @@
 "iw9-pP-alf.title" = "제거";
 
 /* Class = "NSButtonCell"; title = "Remove"; ObjectID = "oQU-Vk-TEO"; */
-"oQU-Vk-TEO.title" = "제거";
+"oQU-Vk-TEO.title" = "제거…";
 
 /* Class = "NSMenuItem"; title = "Check for Update"; ObjectID = "ovG-l7-8cL"; */
 "ovG-l7-8cL.title" = "업데이트 확인";

--- a/Resources/ko.lproj/Main.strings
+++ b/Resources/ko.lproj/Main.strings
@@ -149,5 +149,8 @@
 /* Class = "NSTextFieldCell"; title = "Select the items you wish to remove:"; ObjectID = "z6z-xJ-Pjk"; */
 "z6z-xJ-Pjk.title" = "삭제하고 싶은 항목들을 선택하세요:";
 
+/* Class = "NSTextFieldCell"; title = "Select the items you wish to remove:"; ObjectID = "4Es-9R-gAn"; */
+"4Es-9R-gAn.title" = "삭제하고 싶은 항목들을 선택하세요:";
+
 /* Class = "NSWindow"; title = "Preferences"; ObjectID = "zCt-fj-HIv"; */
 "zCt-fj-HIv.title" = "설정";

--- a/Resources/nl.lproj/Main.strings
+++ b/Resources/nl.lproj/Main.strings
@@ -139,6 +139,9 @@
 /* Class = "NSTextFieldCell"; title = "Select the items you wish to remove:"; ObjectID = "z6z-xJ-Pjk"; */
 "z6z-xJ-Pjk.title" = "Selecteer de onderdelen die u wilt verwijderen:";
 
+/* Class = "NSTextFieldCell"; title = "Select the items you wish to remove:"; ObjectID = "4Es-9R-gAn"; */
+"4Es-9R-gAn.title" = "Selecteer de onderdelen die u wilt verwijderen:";
+
 /* Class = "NSWindow"; title = "Preferences"; ObjectID = "zCt-fj-HIv"; */
 "zCt-fj-HIv.title" = "Voorkeuren";
 

--- a/Resources/nl.lproj/Main.strings
+++ b/Resources/nl.lproj/Main.strings
@@ -17,10 +17,10 @@
 "5qX-Sa-tJD.headerCell.title" = "Architectuur";
 
 /* Class = "NSButtonCell"; title = "Remove"; ObjectID = "7bE-Hh-5SU"; */
-"7bE-Hh-5SU.title" = "Verwijder";
+"7bE-Hh-5SU.title" = "Verwijder…";
 
 /* Class = "NSBox"; title = "Directories:"; ObjectID = "55G-Fd-xJZ"; */
-"55G-Fd-xJZ.title" = "Locaties:";
+"55G-Fd-xJZ.title" = "Locaties";
 
 /* Class = "NSMenu"; title = "Main Menu"; ObjectID = "AYu-sK-qS6"; */
 "AYu-sK-qS6.title" = "Hoofdmenu";
@@ -104,7 +104,7 @@
 "iw9-pP-alf.title" = "Verwijder";
 
 /* Class = "NSButtonCell"; title = "Remove"; ObjectID = "oQU-Vk-TEO"; */
-"oQU-Vk-TEO.title" = "Verwijder";
+"oQU-Vk-TEO.title" = "Verwijder…";
 
 /* Class = "NSMenuItem"; title = "Check for Update"; ObjectID = "ovG-l7-8cL"; */
 "ovG-l7-8cL.title" = "Zoek naar updates";

--- a/Resources/pl.lproj/Main.strings
+++ b/Resources/pl.lproj/Main.strings
@@ -139,6 +139,9 @@
 /* Class = "NSTextFieldCell"; title = "Select the items you wish to remove:"; ObjectID = "z6z-xJ-Pjk"; */
 "z6z-xJ-Pjk.title" = "Wybierz język(i) które chcesz usunąć:";
 
+/* Class = "NSTextFieldCell"; title = "Select the items you wish to remove:"; ObjectID = "4Es-9R-gAn"; */
+"4Es-9R-gAn.title" = "Wybierz język(i) które chcesz usunąć:";
+
 /* Class = "NSWindow"; title = "Preferences"; ObjectID = "zCt-fj-HIv"; */
 "zCt-fj-HIv.title" = "Preferences";
 

--- a/Resources/pl.lproj/Main.strings
+++ b/Resources/pl.lproj/Main.strings
@@ -17,10 +17,10 @@
 "5qX-Sa-tJD.headerCell.title" = "Architecture";
 
 /* Class = "NSButtonCell"; title = "Remove"; ObjectID = "7bE-Hh-5SU"; */
-"7bE-Hh-5SU.title" = "Usuń";
+"7bE-Hh-5SU.title" = "Usuń…";
 
 /* Class = "NSBox"; title = "Directories:"; ObjectID = "55G-Fd-xJZ"; */
-"55G-Fd-xJZ.title" = "Directories:";
+"55G-Fd-xJZ.title" = "Directories";
 
 /* Class = "NSMenu"; title = "Main Menu"; ObjectID = "AYu-sK-qS6"; */
 "AYu-sK-qS6.title" = "Main Menu";
@@ -104,7 +104,7 @@
 "iw9-pP-alf.title" = "Usuń";
 
 /* Class = "NSButtonCell"; title = "Remove"; ObjectID = "oQU-Vk-TEO"; */
-"oQU-Vk-TEO.title" = "Usuń";
+"oQU-Vk-TEO.title" = "Usuń…";
 
 /* Class = "NSMenuItem"; title = "Check for Update"; ObjectID = "ovG-l7-8cL"; */
 "ovG-l7-8cL.title" = "Check for Update";

--- a/Resources/ro.lproj/Main.strings
+++ b/Resources/ro.lproj/Main.strings
@@ -139,6 +139,9 @@
 /* Class = "NSTextFieldCell"; title = "Select the items you wish to remove:"; ObjectID = "z6z-xJ-Pjk"; */
 "z6z-xJ-Pjk.title" = "Selectează elementele pe care vrei să le elimini:";
 
+/* Class = "NSTextFieldCell"; title = "Select the items you wish to remove:"; ObjectID = "4Es-9R-gAn"; */
+"4Es-9R-gAn.title" = "Selectează elementele pe care vrei să le elimini:";
+
 /* Class = "NSWindow"; title = "Preferences"; ObjectID = "zCt-fj-HIv"; */
 "zCt-fj-HIv.title" = "Setări";
 

--- a/Resources/ro.lproj/Main.strings
+++ b/Resources/ro.lproj/Main.strings
@@ -17,10 +17,10 @@
 "5qX-Sa-tJD.headerCell.title" = "Arhitectură";
 
 /* Class = "NSButtonCell"; title = "Remove"; ObjectID = "7bE-Hh-5SU"; */
-"7bE-Hh-5SU.title" = "Elimină";
+"7bE-Hh-5SU.title" = "Elimină…";
 
 /* Class = "NSBox"; title = "Directories:"; ObjectID = "55G-Fd-xJZ"; */
-"55G-Fd-xJZ.title" = "Directoare:";
+"55G-Fd-xJZ.title" = "Directoare";
 
 /* Class = "NSMenu"; title = "Main Menu"; ObjectID = "AYu-sK-qS6"; */
 "AYu-sK-qS6.title" = "Meniu principal";
@@ -104,7 +104,7 @@
 "iw9-pP-alf.title" = "Elimină";
 
 /* Class = "NSButtonCell"; title = "Remove"; ObjectID = "oQU-Vk-TEO"; */
-"oQU-Vk-TEO.title" = "Elimină";
+"oQU-Vk-TEO.title" = "Elimină…";
 
 /* Class = "NSMenuItem"; title = "Check for Update"; ObjectID = "ovG-l7-8cL"; */
 "ovG-l7-8cL.title" = "Caută după actualizări";

--- a/Resources/ru.lproj/Main.strings
+++ b/Resources/ru.lproj/Main.strings
@@ -17,10 +17,10 @@
 "5qX-Sa-tJD.headerCell.title" = "Архитектура";
 
 /* Class = "NSButtonCell"; title = "Remove"; ObjectID = "7bE-Hh-5SU"; */
-"7bE-Hh-5SU.title" = "Удалить";
+"7bE-Hh-5SU.title" = "Удалить…";
 
 /* Class = "NSBox"; title = "Directories:"; ObjectID = "55G-Fd-xJZ"; */
-"55G-Fd-xJZ.title" = "Каталоги:";
+"55G-Fd-xJZ.title" = "Каталоги";
 
 /* Class = "NSMenu"; title = "Main Menu"; ObjectID = "AYu-sK-qS6"; */
 "AYu-sK-qS6.title" = "Главное меню";
@@ -104,7 +104,7 @@
 "iw9-pP-alf.title" = "Удалить";
 
 /* Class = "NSButtonCell"; title = "Remove"; ObjectID = "oQU-Vk-TEO"; */
-"oQU-Vk-TEO.title" = "Удалить";
+"oQU-Vk-TEO.title" = "Удалить…";
 
 /* Class = "NSMenuItem"; title = "Check for Update"; ObjectID = "ovG-l7-8cL"; */
 "ovG-l7-8cL.title" = "Проверить обновления";

--- a/Resources/ru.lproj/Main.strings
+++ b/Resources/ru.lproj/Main.strings
@@ -139,6 +139,9 @@
 /* Class = "NSTextFieldCell"; title = "Select the items you wish to remove:"; ObjectID = "z6z-xJ-Pjk"; */
 "z6z-xJ-Pjk.title" = "Выберите элементы, которые вы хотите удалить:";
 
+/* Class = "NSTextFieldCell"; title = "Select the items you wish to remove:"; ObjectID = "4Es-9R-gAn"; */
+"4Es-9R-gAn.title" = "Выберите элементы, которые вы хотите удалить:";
+
 /* Class = "NSWindow"; title = "Preferences"; ObjectID = "zCt-fj-HIv"; */
 "zCt-fj-HIv.title" = "Настройки";
 

--- a/Resources/sv.lproj/Main.strings
+++ b/Resources/sv.lproj/Main.strings
@@ -139,6 +139,9 @@
 /* Class = "NSTextFieldCell"; title = "Select the items you wish to remove:"; ObjectID = "z6z-xJ-Pjk"; */
 "z6z-xJ-Pjk.title" = "Välj språken du vill ta bort:";
 
+/* Class = "NSTextFieldCell"; title = "Select the items you wish to remove:"; ObjectID = "4Es-9R-gAn"; */
+"4Es-9R-gAn.title" = "Välj språken du vill ta bort:";
+
 /* Class = "NSWindow"; title = "Preferences"; ObjectID = "zCt-fj-HIv"; */
 "zCt-fj-HIv.title" = "Preferences";
 

--- a/Resources/sv.lproj/Main.strings
+++ b/Resources/sv.lproj/Main.strings
@@ -17,10 +17,10 @@
 "5qX-Sa-tJD.headerCell.title" = "Architecture";
 
 /* Class = "NSButtonCell"; title = "Remove"; ObjectID = "7bE-Hh-5SU"; */
-"7bE-Hh-5SU.title" = "Ta bort";
+"7bE-Hh-5SU.title" = "Ta bort…";
 
 /* Class = "NSBox"; title = "Directories:"; ObjectID = "55G-Fd-xJZ"; */
-"55G-Fd-xJZ.title" = "Directories:";
+"55G-Fd-xJZ.title" = "Directories";
 
 /* Class = "NSMenu"; title = "Main Menu"; ObjectID = "AYu-sK-qS6"; */
 "AYu-sK-qS6.title" = "Main Menu";
@@ -104,7 +104,7 @@
 "iw9-pP-alf.title" = "Ta bort";
 
 /* Class = "NSButtonCell"; title = "Remove"; ObjectID = "oQU-Vk-TEO"; */
-"oQU-Vk-TEO.title" = "Ta bort";
+"oQU-Vk-TEO.title" = "Ta bort…";
 
 /* Class = "NSMenuItem"; title = "Check for Update"; ObjectID = "ovG-l7-8cL"; */
 "ovG-l7-8cL.title" = "Check for Update";


### PR DESCRIPTION
- Adjust the component positions to the alignment guides.
- Add an ellipsis to the “Remove” button to indicate that a follow-up action is required (per [Apple’s HIG](https://developer.apple.com/library/mac/documentation/UserExperience/Conceptual/OSXHIGuidelines/ControlsButtons.html#//apple_ref/doc/uid/20000957-CH48-SW1)).
- Replace the add/remove buttons in the preferences window with a segmented control like in Finder’s preferences.
- Move the label in the main window in to the tab view, as the text refers to the table views inside of the tab view.